### PR TITLE
[hrpsys_ros_bridge_tutorials] config.cmake does not depends on the libraries of hrpsys and openhrp3 

### DIFF
--- a/hrpsys_ros_bridge_tutorials/catkin.cmake
+++ b/hrpsys_ros_bridge_tutorials/catkin.cmake
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_ros_bridge_tutorials)
 
 #find_package(catkin REQUIRED COMPONENTS hrpsys_ros_bridge hrpsys openhrp3)
-find_package(catkin REQUIRED COMPONENTS hrpsys_ros_bridge euscollada rostest)
+find_package(catkin REQUIRED COMPONENTS hrpsys_ros_bridge euscollada rostest hrpsys)
 
 set(PKG_CONFIG_PATH "${openhrp3_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH}") # for openrtm3.1.pc
 execute_process(
@@ -15,14 +15,15 @@ if(NOT RESULT EQUAL 0)
 endif()
 set(OPENHRP_SAMPLE_DIR ${OPENHRP_IDL_DIR}/../sample)
 
-find_package(PkgConfig)
-pkg_check_modules(hrpsys hrpsys-base REQUIRED)
 if(NOT EXISTS ${hrpsys_ros_bridge_SOURCE_DIR}) # for installed package
   set(hrpsys_ros_bridge_SOURCE_DIR ${hrpsys_ros_bridge_PREFIX}/share/hrpsys_ros_bridge)
 endif()
 
+unset(hrpsys_LIBRARIES CACHE)
+unset(openhrp3_LIBRARIES CACHE)
+
 catkin_package(
-    DEPENDS openhrp3 hrpsys-base
+    DEPENDS openhrp3 hrpsys
     CATKIN_DEPENDS hrpsys_ros_bridge euscollada
     INCLUDE_DIRS # TODO include
     LIBRARIES # TODO


### PR DESCRIPTION
similar technique to [hrpsys_ros_bridge](https://github.com/start-jsk/rtmros_common/blob/master/hrpsys_ros_bridge/catkin.cmake#L72).

remove dependency to the libraries of hrpsys and openhrp3 from the cmake file of hrpsys_ros_bridge_tutorials (hrpsys_ros_bridge_tutorialsConfig.cmake), which is auto-generated by catkin.

If it depends on those libraries, it will cause error on the packages which depends on hrpsys_ros_bridge_tutorials.

```
CMake Error at /home/travis/ros/ws_rtmros_gazebo/devel/share/hrpsys_ros_bridge_tutorials/cmake/hrpsys_ros_bridge_tutorialsConfig.cmake:141 (message):
  Project 'hrpsys_gazebo_tutorials' tried to find library 'hrpCollision-3.1'.
  The library is neither a target nor built/installed properly.  Did you
  compile project 'hrpsys_ros_bridge_tutorials'? Did you find_package() it
  before the subdirectory containing its code is included?
Call Stack (most recent call first):
  /opt/ros/groovy/share/catkin/cmake/catkinConfig.cmake:72 (find_package)
  rtmros_gazebo/hrpsys_gazebo_tutorials/catkin.cmake:5 (find_package)
  rtmros_gazebo/hrpsys_gazebo_tutorials/CMakeLists.txt:2 (include)
```

related to https://github.com/start-jsk/rtmros_gazebo/pull/26
