### PR TITLE
fix hrp2 waist joint pitch and yaw alias in yaml

### DIFF
--- a/hrpsys_ros_bridge_tutorials/models/hrp2jsk.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/hrp2jsk.yaml
@@ -17,8 +17,8 @@ lleg:
   - LLEG_JOINT4  : lleg-ankle-p
   - LLEG_JOINT5  : lleg-ankle-r
 torso:
-  - CHEST_JOINT0 : torso-waist-p
-  - CHEST_JOINT1 : torso-waist-y
+  - CHEST_JOINT0 : torso-waist-y
+  - CHEST_JOINT1 : torso-waist-p
 head:
   - HEAD_JOINT0  : head-neck-y
   - HEAD_JOINT1  : head-neck-p

--- a/hrpsys_ros_bridge_tutorials/models/hrp2jsknt.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/hrp2jsknt.yaml
@@ -19,8 +19,8 @@ lleg:
   - LLEG_JOINT5  : lleg-ankle-r
   - LLEG_JOINT6  : lleg-toe-p
 torso:
-  - CHEST_JOINT0 : torso-waist-p
-  - CHEST_JOINT1 : torso-waist-y
+  - CHEST_JOINT0 : torso-waist-y
+  - CHEST_JOINT1 : torso-waist-p
 head:
   - HEAD_JOINT0  : head-neck-y
   - HEAD_JOINT1  : head-neck-p

--- a/hrpsys_ros_bridge_tutorials/models/hrp2jsknts.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/hrp2jsknts.yaml
@@ -19,8 +19,8 @@ lleg:
   - LLEG_JOINT5  : lleg-ankle-r
   - LLEG_JOINT6  : lleg-toe-p
 torso:
-  - CHEST_JOINT0 : torso-waist-p
-  - CHEST_JOINT1 : torso-waist-y
+  - CHEST_JOINT0 : torso-waist-y
+  - CHEST_JOINT1 : torso-waist-p
 head:
   - HEAD_JOINT0  : head-neck-y
   - HEAD_JOINT1  : head-neck-p


### PR DESCRIPTION
Joint waist-p and waist-y is reversed for hrp2jsk, hrp2jsknt, and hrp2jsknts.
I checked that eus model moves correctly by this modification.
