### PR TITLE
do not generate "done file" under non existing directory and generate it under build the directory at the top level of the catkin workspace

### DIFF
--- a/hrpsys_ros_bridge_tutorials/catkin.cmake
+++ b/hrpsys_ros_bridge_tutorials/catkin.cmake
@@ -93,10 +93,10 @@ macro(gen_minmax_table_for_closed_robots _OpenHRP2_robot_vrml_name _OpenHRP2_rob
     string(TOLOWER ${_OpenHRP2_robot_name} _sname)
     set(_workdir ${PROJECT_SOURCE_DIR}/models)
     set(_gen_jointmm_command_arg "\"\\(write-min-max-table \\(${_sname}\\) \\\"${_workdir}/${_sname}.l\\\" :margin 1.0\\)\"")
-    add_custom_command(OUTPUT ${PROJECT_SOURCE_DIR}/build/${_sname}_joint_minmax_done
-      COMMAND rosrun roseus roseus ${PROJECT_SOURCE_DIR}/euslisp/make-joint-min-max-table.l ${_workdir}/${_sname}.l "\"${_gen_jointmm_command_arg}\"" "\"(exit)\"" && touch ${PROJECT_SOURCE_DIR}/build/${_sname}_joint_minmax_done
+    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${_sname}_joint_minmax_done
+      COMMAND rosrun roseus roseus ${PROJECT_SOURCE_DIR}/euslisp/make-joint-min-max-table.l ${_workdir}/${_sname}.l "\"${_gen_jointmm_command_arg}\"" "\"(exit)\"" && touch ${CMAKE_CURRENT_BINARY_DIR}/${_sname}_joint_minmax_done
       DEPENDS ${_workdir}/${_sname}.l)
-    add_custom_target(${_sname}_${PROJECT_NAME}_compile2 ALL DEPENDS ${PROJECT_SOURCE_DIR}/build/${_sname}_joint_minmax_done ${_sname}_${PROJECT_NAME}_compile)
+    add_custom_target(${_sname}_${PROJECT_NAME}_compile2 ALL DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/${_sname}_joint_minmax_done ${_sname}_${PROJECT_NAME}_compile)
   endif()
 endmacro()
 


### PR DESCRIPTION
generate "done file" under `${CMAKE_CURRENT_BINARY_DIR}` rather than `${PROJECT_SOURCE_DIR}/build`
Because that build directory is not avaialble on catkin
