### PR TITLE
Remove old dependency on jsk_recognition

### DIFF
--- a/.rosinstall
+++ b/.rosinstall
@@ -14,9 +14,6 @@
     uri: https://github.com/jsk-ros-pkg/jsk_common
     local-name: jsk-ros-pkg/jsk_common
 - git:
-    uri: https://github.com/jsk-ros-pkg/jsk_recognition
-    local-name: jsk-ros-pkg/jsk_recognition
-- git:
     uri: https://github.com/jsk-ros-pkg/jsk_model_tools
     local-name: jsk-ros-pkg/jsk_model_tools
 - git:

--- a/hrpsys_ros_bridge_tutorials/manifest.xml
+++ b/hrpsys_ros_bridge_tutorials/manifest.xml
@@ -40,8 +40,6 @@ Following scripts are only for internal usage:
 
   <!-- examples -->
   <rosdep name="rviz"/>
-  <depend package="jsk_perception" />
-  <depend package="image_view2" />
   <depend package="pr2eus"/>
 </package>
 


### PR DESCRIPTION
(.rosinstall, manifest.xml) : Remove old dependency on jsk_recognition.
These dependencies are already removed from package.xml for hydro environments
