### PR TITLE
Fix hrpsys_gazebo_tutorials to pass travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,6 @@ install: # Use this to install any prerequisites or dependencies necessary to ru
   - if [ $USE_DEB == false -o $BUILDER == rosbuild ]; then $ROSWS set $REPOSITORY_NAME http://github.com/$TRAVIS_REPO_SLUG --git -y        ; fi
   - ln -s $CI_SOURCE_PATH . # Link the repo we are testing to the new workspace
   - cd ../
-  - rm -fr $CI_SOURCE_PATH/hrpsys_gazebo_tutorials
   # Install dependencies for source repos
   - find -L src -name package.xml -exec dirname {} \; | xargs -n 1 -i find {} -name manifest.xml | xargs -n 1 -i mv {} {}.deprecated # rename manifest.xml for rosdep install
   - rosdep install -r -n --from-paths src --ignore-src --rosdistro $ROS_DISTRO -y > /dev/null

--- a/hrpsys_gazebo_tutorials/catkin.cmake
+++ b/hrpsys_gazebo_tutorials/catkin.cmake
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(hrpsys_gazebo_tutorials)
 
-find_package(catkin REQUIRED COMPONENTS euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials)
+find_package(catkin REQUIRED COMPONENTS euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials hrpsys_gazebo_general)
 
 set(PKG_CONFIG_PATH ${hrpsys_PREFIX}/lib/pkgconfig:$ENV{PKG_CONFIG_PATH})
 find_package(PkgConfig)
@@ -9,7 +9,7 @@ pkg_check_modules(openhrp3 openhrp3.1 REQUIRED)
 pkg_check_modules(hrpsys hrpsys-base REQUIRED)
 pkg_check_modules(collada_urdf_jsk_patch collada_urdf_jsk_patch)
 
-catkin_package(CATKIN_DEPENDS euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials)
+catkin_package(CATKIN_DEPENDS euscollada hrpsys_ros_bridge hrpsys_ros_bridge_tutorials hrpsys_gazebo_general)
 
 if(NOT hrpsys_ros_bridge_tutorials_SOURCE_DIR)
   execute_process(


### PR DESCRIPTION
@snozawa さん，https://github.com/start-jsk/rtmros_tutorials/pull/95 や https://github.com/start-jsk/rtmros_tutorials/pull/97 でいろいろお手数おかけして通るようにしていただいた後なので恐縮ですが，
hrpsys_gazebo_generalの新しいdebがリリースされましてhrpsys_gazebo_tutorialsもtravisが通るようになったと思いますので
これで大丈夫そうでしたらマージお願いします．
