### PR TITLE
reduce paralell number: -j2 -l2 -> -j1 -l1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,12 +62,12 @@ before_script: # Use this to prepare your build for testing e.g. copy database c
   - if [ $BUILDER == rosbuild ]; then rospack profile              ; fi
 script: # All commands must exit with code 0 on success. Anything else is considered failure.
   # for catkin
-  # We use CPU number -j2 instead of -j8 in order to obtain stable travis test (https://github.com/start-jsk/rtmros_tutorials/pull/65/files)
-  - if [ $BUILDER == catkin ]; then catkin_make -j2 -l2            ; fi
+  # We use CPU number -j1 instead of -j8 in order to obtain stable travis test (https://github.com/start-jsk/rtmros_tutorials/pull/65/files)
+  - if [ $BUILDER == catkin ]; then catkin_make -j1 -l1            ; fi
   - if [ $BUILDER == catkin ]; then export TARGET_PKG=`find build/$REPOSITORY_NAME -name Makefile -print |  sed s@.*/\\\\\([^\/]*\\\\\)/Makefile@\\\1@g` ; fi
-  - if [ $BUILDER == catkin -a "$TARGET_PKG" != "" ]; then catkin_make test --pkg $TARGET_PKG -j2 -l2  ; fi
+  - if [ $BUILDER == catkin -a "$TARGET_PKG" != "" ]; then catkin_make test --pkg $TARGET_PKG -j1 -l1  ; fi
   - if [ $BUILDER == catkin ]; then find build -name LastTest.log -exec echo "==== {} ====" \; -exec cat {} \;  ; fi
-  - if [ $BUILDER == catkin ]; then catkin_make -j2 -l2 install >/dev/null ; fi
+  - if [ $BUILDER == catkin ]; then catkin_make -j1 -l1 install >/dev/null ; fi
   - if [ $BUILDER == catkin ]; then rm -fr devel src build                 ; fi
   - if [ $BUILDER == catkin ]; then source install/setup.bash              ; fi
   - if [ $BUILDER == catkin -a "$TARGET_PKG" != "" ]; then export EXIT_STATUS=0; for pkg in $TARGET_PKG; do [ "`find install/share/$pkg -iname '*.test'`" == "" ] && echo "[$pkg] No tests ware found!!!"  || find install/share/$pkg -iname "*.test" -print0 | xargs -0 -n1 rostest || export EXIT_STATUS=$?; done; [ $EXIT_STATUS == 0 ] ; fi


### PR DESCRIPTION
travisテストでg++ がメモリ不足で落ちるエラーが頻繁に起きる（ https://travis-ci.org/start-jsk/rtmros_tutorials/pull_requests ）ので，並列の数をもっと減らさないといけない？
50分以内に終わるかも要確認．
