### PR TITLE
Modify staro robotiq straight end coords

### DIFF
--- a/hrpsys_ros_bridge_tutorials/models/staro.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/staro.yaml
@@ -52,6 +52,9 @@ lleg-end-coords:
 rarm-end-coords:
   translate : [0, -0.1893, 0]
   rotate : [0.678598, -0.678598, -0.281085, 148.6]
+larm-end-coords:
+  translate : [0, 0.1893, 0]
+  rotate : [-0.678598, -0.678598, 0.281085, 148.6]
 # larm-end-coords:
 #   translate : [0, 0.1893, 0]
 #   rotate : [0.281085, 0.678598, -0.678598, 148.6]
@@ -67,9 +70,9 @@ rarm-end-coords:
 # rarm-end-coords:
 #   translate : [-0.063286, -0.146, -0.063286]
 #   rotate : [-0.281085, 0.678598, 0.678598, 148.6]
-larm-end-coords:
-  translate : [-0.063286, 0.146, -0.063286]
-  rotate : [0.281085, 0.678598, -0.678598, 148.6]
+# larm-end-coords:
+#   translate : [-0.063286, 0.146, -0.063286]
+#   rotate : [0.281085, 0.678598, -0.678598, 148.6]
 head-end-coords:
   translate : [0.1, 0, 0.2]
   rotate    : [0, 1, 0, 90]

--- a/hrpsys_ros_bridge_tutorials/models/staro.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/staro.yaml
@@ -55,9 +55,6 @@ rarm-end-coords:
 larm-end-coords:
   translate : [0, 0.1893, 0]
   rotate : [-0.678598, -0.678598, 0.281085, 148.6]
-# larm-end-coords:
-#   translate : [0, 0.1893, 0]
-#   rotate : [0.281085, 0.678598, -0.678598, 148.6]
 # side version
 # contact-end-coords
 # rarm-end-coords:

--- a/hrpsys_ros_bridge_tutorials/models/staro.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/staro.yaml
@@ -48,7 +48,7 @@ rleg-end-coords:
   translate : [0.0, 0, -0.096]
 lleg-end-coords:
   translate : [0.0, 0, -0.096]
-# straigh ver
+# straight ver
 rarm-end-coords:
   translate : [0, -0.1893, 0]
   rotate : [0.678598, -0.678598, -0.281085, 148.6]

--- a/hrpsys_ros_bridge_tutorials/models/staro.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/staro.yaml
@@ -49,11 +49,11 @@ rleg-end-coords:
 lleg-end-coords:
   translate : [0.0, 0, -0.096]
 # straigh ver
-# rarm-end-coords:
-#   translate : [-0.063286056916196, -0.1488, -0.063286056916196] # 89.5 / sqrt(2) * 0.001
-#   rotate : [-0.281085, 0.678598, 0.678598, 148.6]
+rarm-end-coords:
+  translate : [0, -0.1893, 0]
+  rotate : [0.678598, -0.678598, -0.281085, 148.6]
 # larm-end-coords:
-#   translate : [-0.063286056916196, 0.1488, -0.063286056916196]
+#   translate : [0, 0.1893, 0]
 #   rotate : [0.281085, 0.678598, -0.678598, 148.6]
 # side version
 # contact-end-coords
@@ -64,9 +64,9 @@ lleg-end-coords:
 #   translate : [0, 0.2393, 0]
 #   rotate : [0.281085, 0.678598, -0.678598, 148.6]
 # grasp-end-coords
-rarm-end-coords:
-  translate : [-0.063286, -0.146, -0.063286]
-  rotate : [-0.281085, 0.678598, 0.678598, 148.6]
+# rarm-end-coords:
+#   translate : [-0.063286, -0.146, -0.063286]
+#   rotate : [-0.281085, 0.678598, 0.678598, 148.6]
 larm-end-coords:
   translate : [-0.063286, 0.146, -0.063286]
   rotate : [0.281085, 0.678598, -0.678598, 148.6]


### PR DESCRIPTION
End-coords of straight-version robotiq hand attachment was wrong in  staro.yaml (This was same as angled-version).