### PR TITLE
Fix update jaxon

### DIFF
--- a/hrpsys_ros_bridge_tutorials/catkin.cmake
+++ b/hrpsys_ros_bridge_tutorials/catkin.cmake
@@ -252,7 +252,7 @@ compile_rbrain_model_for_closed_robots(JAXON jaxon JAXON
   --simulation-timestep-option "0.002"
   --robothardware-conf-file-option "pdgains.file_name: ${PROJECT_SOURCE_DIR}/models/PDgains.sav"
   --conf-file-option "abc_leg_offset: 0.0, 0.1, 0.0"
-  --conf-file-option "end_effectors: rarm,RARM_JOINT7,CHEST_JOINT2,-0.055,0.0,-0.237,-0.57735,0.57735,0.57735,2.0944, larm,LARM_JOINT7,CHEST_JOINT2,-0.055,0.0,-0.237,0.57735,0.57735,-0.57735,2.0944, rleg,RLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0,"
+  --conf-file-option "end_effectors: rarm,RARM_JOINT7,CHEST_JOINT2,-0.055,0.0,-0.237,-0.57735,0.57735,0.57735,2.0944, larm,LARM_JOINT7,CHEST_JOINT2,-0.055,0.0,-0.237,0.57735,0.57735,-0.57735,2.0944, rleg,RLEG_JOINT5,BODY,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT5,BODY,0.0,0.0,-0.096,0.0,0.0,0.0,0.0,"
 )
 
 if(EXISTS ${PROJECT_SOURCE_DIR}/models/TESTMDOFARM.wrl)

--- a/hrpsys_ros_bridge_tutorials/catkin.cmake
+++ b/hrpsys_ros_bridge_tutorials/catkin.cmake
@@ -252,7 +252,7 @@ compile_rbrain_model_for_closed_robots(JAXON jaxon JAXON
   --simulation-timestep-option "0.002"
   --robothardware-conf-file-option "pdgains.file_name: ${PROJECT_SOURCE_DIR}/models/PDgains.sav"
   --conf-file-option "abc_leg_offset: 0.0, 0.1, 0.0"
-  --conf-file-option "end_effectors: rarm,RARM_JOINT7,CHEST_JOINT2,0.0,-0.15701,0.0,0.57735,-0.57735,-0.57735,2.0944, larm,LARM_JOINT7,CHEST_JOINT2,-5.684342e-17,0.15701,-1.136868e-16,-0.57735,-0.57735,0.57735,2.0944, rleg,RLEG_JOINT5,BODY,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT5,BODY,0.0,0.0,-0.096,0.0,0.0,0.0,0.0,"
+  --conf-file-option "end_effectors: rarm,RARM_JOINT7,CHEST_JOINT2,-0.055,0.0,-0.237,-0.57735,0.57735,0.57735,2.0944, larm,LARM_JOINT7,CHEST_JOINT2,-0.055,0.0,-0.237,0.57735,0.57735,-0.57735,2.0944, rleg,RLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0,"
 )
 
 if(EXISTS ${PROJECT_SOURCE_DIR}/models/TESTMDOFARM.wrl)

--- a/hrpsys_ros_bridge_tutorials/catkin.cmake
+++ b/hrpsys_ros_bridge_tutorials/catkin.cmake
@@ -250,6 +250,9 @@ compile_rbrain_model_for_closed_robots(YSTLEG ystleg YSTLEG
 compile_rbrain_model_for_closed_robots(JAXON jaxon JAXON
   --conf-dt-option "0.002"
   --simulation-timestep-option "0.002"
+  --robothardware-conf-file-option "pdgains.file_name: ${PROJECT_SOURCE_DIR}/models/PDgains.sav"
+  --conf-file-option "abc_leg_offset: 0.0, 0.1, 0.0"
+  --conf-file-option "end_effectors: rarm,RARM_JOINT7,CHEST_JOINT2,0.0,-0.15701,0.0,0.57735,-0.57735,-0.57735,2.0944, larm,LARM_JOINT7,CHEST_JOINT2,-5.684342e-17,0.15701,-1.136868e-16,-0.57735,-0.57735,0.57735,2.0944, rleg,RLEG_JOINT5,BODY,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT5,BODY,0.0,0.0,-0.096,0.0,0.0,0.0,0.0,"
 )
 
 if(EXISTS ${PROJECT_SOURCE_DIR}/models/TESTMDOFARM.wrl)


### PR DESCRIPTION
https://github.com/start-jsk/rtmros_tutorials/pull/195 のend-effectorの値が若干違う気がしますが，どうでしょうか？

※PRへのPRの方法が分かりませんでした．．．

```lisp
1.irteusgl$ (setq *robot* (jaxon))
#<jaxon-robot #X5620330 JAXON  0.0 0.0 0.0 / 0.0 0.0 0.0>
2.irteusgl$ (print-end-effector-parameter-conf-from-robot *robot*)
end_effectors: rarm,RARM_JOINT7,CHEST_JOINT2,-0.055,0.0,-0.237,-0.57735,0.57735,0.57735,2.0944, larm,LARM_JOINT7,CHEST_JOINT2,-0.055,0.0,-0.237,0.57735,0.57735,-0.57735,2.0944, rleg,RLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0,
nil
```