### PR TITLE
update staro end-effector info

### DIFF
--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -235,7 +235,7 @@ compile_rbrain_model_for_closed_robots(URATALEG urataleg URATALEG
 compile_rbrain_model_for_closed_robots(STARO staro STARO
   --robothardware-conf-file-option "pdgains.file_name: ${PROJECT_SOURCE_DIR}/models/PDgains.sav"
   --conf-file-option "abc_leg_offset: 0.0, 0.1, 0.0"
-  --conf-file-option "end_effectors: rarm,RARM_JOINT7,CHEST_JOINT1,0.0,-0.15701,0.0,0.57735,-0.57735,-0.57735,2.0944, larm,LARM_JOINT7,CHEST_JOINT1,-5.684342e-17,0.15701,-1.136868e-16,-0.57735,-0.57735,0.57735,2.0944, rleg,RLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0,"
+  --conf-file-option "end_effectors: lleg,LLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, rleg,RLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, rarm,RARM_JOINT7,CHEST_JOINT1,-2.842171e-17,-0.1893,0.0,0.678598,-0.678598,-0.281085,2.59356, larm,LARM_JOINT7,CHEST_JOINT1,-5.684342e-17,0.1893,0.0,-0.678598,-0.678598,0.281085,2.59356,"
   --conf-file-option "torque_offset: 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0,   0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0"
   --conf-file-option "torque_filter_params: 2, 1.0, 1.88903, -0.89487, 0.0014603, 0.0029206, 0.0014603"
   --conf-file-option "error_to_torque_gain: 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0,   0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0"

--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -235,7 +235,7 @@ compile_rbrain_model_for_closed_robots(URATALEG urataleg URATALEG
 compile_rbrain_model_for_closed_robots(STARO staro STARO
   --robothardware-conf-file-option "pdgains.file_name: ${PROJECT_SOURCE_DIR}/models/PDgains.sav"
   --conf-file-option "abc_leg_offset: 0.0, 0.1, 0.0"
-  --conf-file-option "end_effectors: lleg,LLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, rleg,RLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, rarm,RARM_JOINT7,CHEST_JOINT1,-2.842171e-17,-0.1893,0.0,0.678598,-0.678598,-0.281085,2.59356, larm,LARM_JOINT7,CHEST_JOINT1,-5.684342e-17,0.1893,0.0,-0.678598,-0.678598,0.281085,2.59356,"
+  --conf-file-option "end_effectors: rleg,RLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT5,WAIST,0.0,0.0,-0.096,0.0,0.0,0.0,0.0, rarm,RARM_JOINT7,CHEST_JOINT1,-2.842171e-17,-0.1893,0.0,0.678598,-0.678598,-0.281085,2.59356, larm,LARM_JOINT7,CHEST_JOINT1,-5.684342e-17,0.1893,0.0,-0.678598,-0.678598,0.281085,2.59356,"
   --conf-file-option "torque_offset: 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0,   0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0"
   --conf-file-option "torque_filter_params: 2, 1.0, 1.88903, -0.89487, 0.0014603, 0.0029206, 0.0014603"
   --conf-file-option "error_to_torque_gain: 0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0,   0, 0, 0, 0, 0, 0,  0, 0, 0, 0, 0, 0"


### PR DESCRIPTION
eeの順番が違うのを直したのと，腕のeeの位置・回転に謎の値が入っていたのを直しました．
位置は多少の差ですが，回転が大きく違っていました．


@orikuma さんとカツヤに行った時にここらへんの話をした記憶がありますが，
https://github.com/start-jsk/rtmros_tutorials/pull/191 のときにCMakeLists.txtの方が変更されていませんが，特に体内にdiffがあるわけでもなかったので，STAROで手先にインピーダンスを入れたときに回転成分がおかしかったのではないでしょうか．

##### before
```txt
rarm,RARM_JOINT7,CHEST_JOINT1,0.0,-0.15701,0.0,0.57735,-0.57735,-0.57735,2.0944, 
```

##### after

```txt
rarm,RARM_JOINT7,CHEST_JOINT1,-2.842171e-17,-0.1893,0.0,0.678598,-0.678598,-0.281085,2.59356
```

##### 比較

```lisp
(let ((a (make-coords))
      (b (make-coords)))
  (send a :rotate 2.0944 #f(1 -1 -1))
  (send b :rotate 2.59356 #f(0.678598 -0.678598 -0.281085))
  (progn
    (send a :draw-on :flush t :size 100 :color #f(0.8 0.8 0) :width 5)
    (send b :draw-on :flush t :size 150 :color #f(0 0.8 0.8) :width 3))
  )
```

![image](https://cloud.githubusercontent.com/assets/4509039/7443574/2ff01ca4-f192-11e4-98d8-4c94c2c24f06.png)
