### PR TITLE
Fix for karasawa sole plate for hrp2jsknts

### DIFF
--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -154,8 +154,12 @@ compile_openhrp_model_for_closed_robots(HRP2JSKNT HRP2JSKNT_for_OpenHRP3 HRP2JSK
 gen_minmax_table_for_closed_robots(HRP2JSKNT HRP2JSKNT_for_OpenHRP3 HRP2JSKNT)
 compile_openhrp_model_for_closed_robots(HRP2JSKNTS HRP2JSKNTS_for_OpenHRP3 HRP2JSKNTS
   --conf-file-option "abc_leg_offset: 0.0,0.105,0.0"
+  --conf-file-option "# 6dof joint version"
   --conf-file-option "#end_effectors: rleg,RLEG_JOINT5,WAIST,0.035589,-0.01,-0.105,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT5,WAIST,0.035589,0.01,-0.105,0.0,0.0,0.0,0.0, rarm,RARM_JOINT6,CHEST_JOINT1,-0.0042,0.0392,-0.1245,0.0,1.0,0.0,1.5708, larm,LARM_JOINT6,CHEST_JOINT1,-0.0042,-0.0392,-0.1245,0.0,1.0,0.0,1.5708,"
-  --conf-file-option "end_effectors: rleg,RLEG_JOINT6,WAIST,-0.079411,-0.01,-0.031,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT6,WAIST,-0.079411,0.01,-0.031,0.0,0.0,0.0,0.0, rarm,RARM_JOINT6,CHEST_JOINT1,-0.0042,0.0392,-0.1245,0.0,1.0,0.0,1.5708, larm,LARM_JOINT6,CHEST_JOINT1,-0.0042,-0.0392,-0.1245,0.0,1.0,0.0,1.5708,"
+  --conf-file-option "# Original foot + 7dof joint version"
+  --conf-file-option "#end_effectors: rleg,RLEG_JOINT6,WAIST,-0.079411,-0.01,-0.031,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT6,WAIST,-0.079411,0.01,-0.031,0.0,0.0,0.0,0.0, rarm,RARM_JOINT6,CHEST_JOINT1,-0.0042,0.0392,-0.1245,0.0,1.0,0.0,1.5708, larm,LARM_JOINT6,CHEST_JOINT1,-0.0042,-0.0392,-0.1245,0.0,1.0,0.0,1.5708,"
+  --conf-file-option "# Karasawa sole plate + 7dof joint version"
+  --conf-file-option "end_effectors: rleg,RLEG_JOINT6,WAIST,-0.079411,-0.01,-0.034,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT6,WAIST,-0.079411,0.01,-0.034,0.0,0.0,0.0,0.0, rarm,RARM_JOINT6,CHEST_JOINT1,-0.0042,0.0392,-0.1245,0.0,1.0,0.0,1.5708, larm,LARM_JOINT6,CHEST_JOINT1,-0.0042,-0.0392,-0.1245,0.0,1.0,0.0,1.5708,"
   --conf-file-option "# for ThermoEstimator"
   --conf-file-option "motor_heat_params: 0.0075,0.5, 0.003,0.5, 0.003,0.5, 0.003,0.5, 0.003,0.5, 0.0075,0.5, 0.02,0.3, 0.0075,0.5, 0.003,0.5, 0.003,0.5, 0.003,0.5, 0.003,0.5, 0.0075,0.5, 0.02,0.3, 0.003,0.5, 0.003,0.5, 0.2,0.3, 0.2,0.3, 0.003,0.5, 0.003,0.5, 0.02,0.3, 0.003,0.5, 0.2,0.3, 0.2,0.3, 0.2,0.3, 0.2,0.3, 0.003,0.5, 0.003,0.5, 0.02,0.3, 0.003,0.5, 0.2,0.3, 0.2,0.3, 0.2,0.3, 0.2,0.3"
   --conf-file-option "motor_temperature_limit: 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0, 60.0"

--- a/hrpsys_ros_bridge_tutorials/models/hrp2jsknts.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/hrp2jsknts.yaml
@@ -47,9 +47,15 @@ larm:
 ## end-coords
 ##
 rleg-end-coords:
-  translate : [-0.079411, -0.01, -0.031]
+# Original foot
+#  translate : [-0.079411, -0.01, -0.031]
+# Karasawa sole plate [3mm]
+  translate : [-0.079411, -0.01, -0.034]
 lleg-end-coords:
-  translate : [-0.079411,  0.01, -0.031]
+# Original foot
+#  translate : [-0.079411,  0.01, -0.031]
+# Karasawa sole plate [3mm]
+  translate : [-0.079411,  0.01, -0.034]
 torso-end-coords:
   translate : [-0.032, 0.0, -1.0557]
 head-end-coords:


### PR DESCRIPTION
まだマージしないでください。

https://github.com/start-jsk/rtmros_hrp2/pull/157
に対応して、唐澤君あしうらパーツの変更です。
あしうらパーツの分、end-coordsを下げました。