### PR TITLE
Fix parallel compile of hrpsys_ros_bridge_tutorials

### DIFF
--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -393,7 +393,7 @@ macro (run_xacro_for_hand_hrp2_model _robot_name)
 endmacro()
 
 macro (attach_sensor_and_endeffector_to_hrp2jsk_urdf
-    _urdf_file _out_file _yaml_file)
+    _robot_name _urdf_file _out_file _yaml_file)
   set(_model_dir "${PROJECT_SOURCE_DIR}/models/")
   set(_in_urdf_file "${_model_dir}/${_urdf_file}")
   set(_in_yaml_file "${_model_dir}/${_yaml_file}")
@@ -404,7 +404,7 @@ macro (attach_sensor_and_endeffector_to_hrp2jsk_urdf
     ${_in_urdf_file} -O ${_out_urdf_file} -C ${_in_yaml_file}
     DEPENDS ${_in_urdf_file} ${_in_yaml_file} ${_script_file})
   add_custom_target(${_out_file}_generate DEPENDS ${_out_urdf_file})
-  list(APPEND compile_urdf_robots ${_out_file}_generate)
+  list(APPEND compile_${_robot_name}_urdf_robots ${_out_file}_generate)
 endmacro()
 
 # for HRP2JSK + multisense
@@ -416,10 +416,9 @@ if(multisense_description_FOUND)
     COMMAND ${xacro_exe} ${_model_dir}/HRP2JSK.urdf.xacro > ${_model_dir}/HRP2JSK_WH.urdf
     DEPENDS ${_model_dir}/HRP2JSK.urdf.xacro ${_model_dir}/HRP2JSK.urdf)
   # generate HRP2JSK_WH_SENSORS.urdf from HRP2JSK_WH.urdf and yaml
-  attach_sensor_and_endeffector_to_hrp2jsk_urdf(HRP2JSK_WH.urdf
+  attach_sensor_and_endeffector_to_hrp2jsk_urdf(HRP2JSK HRP2JSK_WH.urdf
     HRP2JSK_WH_SENSORS.urdf hrp2jsk.yaml)
-  add_custom_target(HRP2JSK_model_generate DEPENDS ${_model_dir}/HRP2JSK_WH_SENSORS.urdf)
-  list(APPEND compile_urdf_robots HRP2JSK_model_generate)
+  add_custom_target(all_hrp2jsk_model_generate ALL DEPENDS ${compile_HRP2JSK_urdf_robots})
 endif(multisense_description_FOUND)
 
 if(EXISTS ${hrp2_models_MODEL_DIR}/HRP3HAND_R/HRP3HAND_Rmain.wrl)
@@ -429,12 +428,13 @@ if(EXISTS ${hrp2_models_MODEL_DIR}/HRP3HAND_R/HRP3HAND_Rmain.wrl)
   pkg_check_modules(multisense_description multisense_description QUIET)
   if(multisense_description_FOUND)
     run_xacro_for_hand_hrp2_model(HRP2JSKNTS)
-    attach_sensor_and_endeffector_to_hrp2jsk_urdf(HRP2JSKNTS_WH.urdf
+    attach_sensor_and_endeffector_to_hrp2jsk_urdf(HRP2JSKNTS HRP2JSKNTS_WH.urdf
       HRP2JSKNTS_WH_SENSORS.urdf hrp2jsknts.yaml)
-    attach_sensor_and_endeffector_to_hrp2jsk_urdf(HRP2JSKNT_WH.urdf
+    attach_sensor_and_endeffector_to_hrp2jsk_urdf(HRP2JSKNT HRP2JSKNT_WH.urdf
       HRP2JSKNT_WH_SENSORS.urdf hrp2jsknt.yaml)
   endif(multisense_description_FOUND)
-  add_custom_target(all_robots_model_generate ALL DEPENDS ${compile_urdf_robots})
+  add_custom_target(all_hrp2jsknt_model_generate ALL DEPENDS ${compile_HRP2JSKNT_urdf_robots})
+  add_custom_target(all_hrp2jsknts_model_generate ALL DEPENDS ${compile_HRP2JSKNTS_urdf_robots})
 endif()
 
 macro (generate_staro_hand_model _robot_name _dir_name)

--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -29,6 +29,11 @@ catkin_package(
     LIBRARIES # TODO
 )
 
+################################
+## compile_openhrp_model
+##  Generate OpenHRP3 .xml and .conf file.
+##  Convert .wrl, .dae, and .l files
+################################
 if(EXISTS ${hrpsys_PREFIX}/share/hrpsys/samples/HRP4C/HRP4Cmain.wrl)
   compile_openhrp_model(
     ${hrpsys_PREFIX}/share/hrpsys/samples/HRP4C/HRP4Cmain.wrl
@@ -317,6 +322,10 @@ if(EXISTS ${PROJECT_SOURCE_DIR}/models/TESTMDOFARM.wrl)
     TESTMDOFARM)
 endif()
 
+
+################################
+## Generate default simulation launch files and euslisp interface files
+################################
 macro (generate_default_launch_eusinterface_files_for_jsk_closed_openhrp_robots ROBOT_DIR ROBOT_NAME)
   set(_arg_list ${ARGV})
   # remove arguments of this macro
@@ -351,6 +360,13 @@ generate_default_launch_eusinterface_files(
   "--no-euslisp")
 generate_default_launch_eusinterface_files("$(find openhrp3)/share/OpenHRP-3.1/sample/model/sample1.wrl" hrpsys_ros_bridge_tutorials SampleRobot "--use-unstable-hrpsys-config")
 
+################################
+## Generate and modify .urdf files
+##   Org file : ROBOT.urdf, ROBOT.urdf.xacro
+##   generate_hand_attached_xx_model : Generate ROBOT_body.urdf from ROBOT.urdf, ROBOT.urdf.xacro
+##   run_xacro_for_hand_hrp2_model : Generate ROBOT_WH.urdf from ROBOT_body.urdf
+##   attach_sensor_and_endeffector_to_hrp2jsk_urdf : Generate ROBOT_WH_SESNROS.urdf from ROBOT_WR.urdf
+################################
 # find xacro
 find_package(xacro)
 if(EXISTS ${xacro_SOURCE_PREFIX}/xacro.py)

--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -425,7 +425,7 @@ endmacro()
 
 # for HRP2JSK + multisense
 pkg_check_modules(multisense_description multisense_description QUIET)
-if(multisense_description_FOUND)
+if(${hrp2_models_FOUND} AND multisense_description_FOUND)
   # generate HRP2JSK_WH.urdf from HRP2JSK.urdf.xacro
   set(_model_dir "${PROJECT_SOURCE_DIR}/models/")
   add_custom_command(OUTPUT ${_model_dir}/HRP2JSK_WH.urdf
@@ -558,7 +558,9 @@ if(EXISTS ${jsk_models_MODEL_DIR}/JAXON/l_hand_attached_link.dae)
     endif()
   endif()
 endif()
-add_custom_target(all_urdf_model_generate ALL DEPENDS ${compile_urdf_robots})
+if (DEFINED compile_urdf_robots)
+  add_custom_target(all_urdf_model_generate ALL DEPENDS ${compile_urdf_robots})
+endif()
 
 install(DIRECTORY euslisp launch scripts models test DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION} USE_SOURCE_PERMISSIONS)
 install(CODE

--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -404,7 +404,7 @@ macro (attach_sensor_and_endeffector_to_hrp2jsk_urdf
     ${_in_urdf_file} -O ${_out_urdf_file} -C ${_in_yaml_file}
     DEPENDS ${_in_urdf_file} ${_in_yaml_file} ${_script_file})
   add_custom_target(${_out_file}_generate DEPENDS ${_out_urdf_file})
-  list(APPEND compile_${_robot_name}_urdf_robots ${_out_file}_generate)
+  list(APPEND compile_urdf_robots ${_out_file}_generate)
 endmacro()
 
 # for HRP2JSK + multisense
@@ -418,7 +418,6 @@ if(multisense_description_FOUND)
   # generate HRP2JSK_WH_SENSORS.urdf from HRP2JSK_WH.urdf and yaml
   attach_sensor_and_endeffector_to_hrp2jsk_urdf(HRP2JSK HRP2JSK_WH.urdf
     HRP2JSK_WH_SENSORS.urdf hrp2jsk.yaml)
-  add_custom_target(all_hrp2jsk_model_generate ALL DEPENDS ${compile_HRP2JSK_urdf_robots})
 endif(multisense_description_FOUND)
 
 if(EXISTS ${hrp2_models_MODEL_DIR}/HRP3HAND_R/HRP3HAND_Rmain.wrl)
@@ -433,8 +432,6 @@ if(EXISTS ${hrp2_models_MODEL_DIR}/HRP3HAND_R/HRP3HAND_Rmain.wrl)
     attach_sensor_and_endeffector_to_hrp2jsk_urdf(HRP2JSKNT HRP2JSKNT_WH.urdf
       HRP2JSKNT_WH_SENSORS.urdf hrp2jsknt.yaml)
   endif(multisense_description_FOUND)
-  add_custom_target(all_hrp2jsknt_model_generate ALL DEPENDS ${compile_HRP2JSKNT_urdf_robots})
-  add_custom_target(all_hrp2jsknts_model_generate ALL DEPENDS ${compile_HRP2JSKNTS_urdf_robots})
 endif()
 
 macro (generate_staro_hand_model _robot_name _dir_name)
@@ -495,7 +492,7 @@ macro (attach_sensor_and_endeffector_to_staro_urdf
     COMMAND ${_script_file} ${_robot_name} ${euscollada_PACKAGE_PATH} ${_in_urdf_file} ${_out_urdf_file} ${_in_yaml_file}
     DEPENDS ${_in_urdf_file} ${_in_yaml_file} ${_script_file})
   add_custom_target(${_out_file}_generate DEPENDS ${_out_urdf_file})
-  list(APPEND compile_${_robot_name}_urdf_robots ${_out_file}_generate)
+  list(APPEND compile_urdf_robots ${_out_file}_generate)
 endmacro()
 
 if(EXISTS ${jsk_models_MODEL_DIR}/STARO/l_hand_attached_link.dae)
@@ -507,7 +504,6 @@ if(EXISTS ${jsk_models_MODEL_DIR}/STARO/l_hand_attached_link.dae)
     generate_hand_attached_staro_model(STARO)
     run_xacro_for_hand_staro_model(STARO)
     attach_sensor_and_endeffector_to_staro_urdf(STARO STARO_WH.urdf STARO_WH_SENSORS.urdf staro.yaml)
-    add_custom_target(all_staro_model_generate ALL DEPENDS ${compile_STARO_urdf_robots})
   endif()
 endif()
 
@@ -525,7 +521,6 @@ if(EXISTS ${jsk_models_MODEL_DIR}/JAXON/l_hand_attached_link.dae)
       generate_hand_attached_staro_model(JAXON)
       run_xacro_for_hand_staro_model(JAXON)
       attach_sensor_and_endeffector_to_staro_urdf(JAXON JAXON_WH.urdf JAXON_WH_SENSORS.urdf jaxon.yaml)
-      add_custom_target(all_jaxon_model_generate ALL DEPENDS ${compile_JAXON_urdf_robots})
     endif()
   endif()
 endif()
@@ -544,10 +539,10 @@ if(EXISTS ${jsk_models_MODEL_DIR}/JAXON/l_hand_attached_link.dae)
       generate_hand_attached_staro_model(JAXON_RED)
       run_xacro_for_hand_staro_model(JAXON_RED)
       attach_sensor_and_endeffector_to_staro_urdf(JAXON_RED JAXON_RED_WH.urdf JAXON_RED_WH_SENSORS.urdf jaxon_red.yaml)
-      add_custom_target(all_jaxon_red_model_generate ALL DEPENDS ${compile_JAXON_RED_urdf_robots})
     endif()
   endif()
 endif()
+add_custom_target(all_urdf_model_generate ALL DEPENDS ${compile_urdf_robots})
 
 install(DIRECTORY euslisp launch scripts models test DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION} USE_SOURCE_PERMISSIONS)
 install(CODE

--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -377,8 +377,6 @@ macro (generate_hand_attached_hrp2_model _robot_name)
       COMMAND ${_script_file}
       LARM_LINK6 RARM_LINK6 ${_in_urdf_file} ${_out_urdf_file}
       DEPENDS ${_in_urdf_file} ${_script_file})
-  add_custom_target(${_robot_name}_model_generate DEPENDS ${_out_urdf_file})
-  list(APPEND compile_urdf_robots ${_robot_name}_model_generate)
 endmacro()
 
 macro (run_xacro_for_hand_hrp2_model _robot_name)
@@ -392,8 +390,6 @@ macro (run_xacro_for_hand_hrp2_model _robot_name)
       COMMAND ${xacro_exe} ${_in_xacro_file} > ${_out_urdf_file}
       DEPENDS ${_in_xacro_file} ${_in_body_urdf}
       ${_in_hand_l_urdf} ${_in_hand_r_urdf})
-  add_custom_target(${_robot_name}_xacro_model_generate DEPENDS ${_out_urdf_file})
-  list(APPEND compile_urdf_robots ${_robot_name}_xacro_model_generate)
 endmacro()
 
 macro (attach_sensor_and_endeffector_to_hrp2jsk_urdf
@@ -476,8 +472,6 @@ macro (generate_hand_attached_staro_model _robot_name)
   add_custom_command(OUTPUT ${_out_urdf_file}
       COMMAND ${_script_file} ${_robot_name} ${_in_urdf_file} ${euscollada_PACKAGE_PATH}
       DEPENDS ${_in_urdf_file})
-  add_custom_target(${_robot_name}_model_generate DEPENDS ${_out_urdf_file})
-  list(APPEND compile_${_robot_name}_urdf_robots ${_robot_name}_model_generate)
 endmacro()
 
 macro (run_xacro_for_hand_staro_model _robot_name)
@@ -488,8 +482,6 @@ macro (run_xacro_for_hand_staro_model _robot_name)
   add_custom_command(OUTPUT ${_out_urdf_file}
       COMMAND ${xacro_exe} ${_in_xacro_file} > ${_out_urdf_file}
       DEPENDS ${_in_xacro_file} ${_in_body_urdf})
-  add_custom_target(${_robot_name}_xacro_model_generate DEPENDS ${_out_urdf_file})
-  list(APPEND compile_${_robot_name}_urdf_robots ${_robot_name}_xacro_model_generate)
 endmacro()
 
 macro (attach_sensor_and_endeffector_to_staro_urdf

--- a/hrpsys_ros_bridge_tutorials/models/HRP2JSK.urdf.xacro
+++ b/hrpsys_ros_bridge_tutorials/models/HRP2JSK.urdf.xacro
@@ -1,4 +1,4 @@
-<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="HRP2JSKNT" >
+<robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="HRP2JSK" >
   <xacro:include filename="HRP2JSK.urdf" />
   <xacro:include filename="$(find multisense_description)/urdf/multisenseSL.urdf" />
   <joint name="hrp2_to_multisense" type="fixed">


### PR DESCRIPTION
Fix parallel compile of hrpsys_ros_bridge_tutorials.
This is intended to solve https://github.com/start-jsk/rtmros_common/pull/754.

Previously, catkin build of hrpsys_ros_bridge_tutorials sometimes successes and failes. 
I checked catkin build many times:
```
roscd hrpsys_ros_bridge_tutorials
SUCCESSNUM=0;NUM=0;while [ $NUM -lt 50 ]; do git clean -xfd . && catkin bt --force-cmake --start-with-this && SUCCESSNUM=`expr $SUCCESSNUM + 1`; NUM=`expr $NUM + 1`;done; echo "SUCCESS $SUCCESSNUM / $NUM"
```

After this PR, I'd like to check rtmros_common and rtmros_hrp2 master branch build.