### PR TITLE
update min-max-table margin of JAXON waist-p joint

### DIFF
--- a/hrpsys_ros_bridge_tutorials/euslisp/make-joint-min-max-table.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/make-joint-min-max-table.l
@@ -104,7 +104,7 @@
             (send robot :torso :waist-p :child-link)
             (send robot :torso :waist-r)
             (send robot :torso :waist-p)
-            :margin 3))
+            :margin 2))
    (send robot :make-joint-min-max-table
       (send robot :head :neck-y :parent-link)
       (send robot :head :neck-p :child-link)


### PR DESCRIPTION
逆そり防止のマージンですが、jaxon_redのモデル修正にともない、問題なさそうなので変更します。
see: https://github.com/start-jsk/rtmros_hrp2/pull/243