### PR TITLE
[hrpsys_ros_bridge_tutorials, hrpsys_gazebo_tutorials] Fix for gazebo simulation.

### DIFF
--- a/hrpsys_gazebo_tutorials/config/HRP2JSKNT.yaml
+++ b/hrpsys_gazebo_tutorials/config/HRP2JSKNT.yaml
@@ -11,7 +11,7 @@ hrpsys_gazebo_configuration:
 ### name of robot (using for namespace)
   robotname: HRP2JSKNT
 ### joint_id (order) conversion from gazebo to hrpsys, joint_id_list[gazebo_id] := hrpsys_id
-  joint_id_list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
+  joint_id_list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45]
 ### joints : list used in gazebo, sizeof(joint_id_list) == sizeof(joints)
   joints:
     - RLEG_JOINT0
@@ -39,6 +39,7 @@ hrpsys_gazebo_configuration:
     - RARM_JOINT4
     - RARM_JOINT5
     - RARM_JOINT6
+    - RARM_JOINT7
     - LARM_JOINT0
     - LARM_JOINT1
     - LARM_JOINT2
@@ -46,6 +47,19 @@ hrpsys_gazebo_configuration:
     - LARM_JOINT4
     - LARM_JOINT5
     - LARM_JOINT6
+    - LARM_JOINT7
+    - L_THUMBCM_Y
+    - L_THUMBCM_P
+    - L_INDEXMP_R
+    - L_INDEXMP_P
+    - L_INDEXPIP_R
+    - L_MIDDLEPIP_R
+    - R_THUMBCM_Y
+    - R_THUMBCM_P
+    - R_INDEXMP_R
+    - R_INDEXMP_P
+    - R_INDEXPIP_R
+    - R_MIDDLEPIP_R
 ## jointid:
   gains:
     CHEST_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
@@ -80,6 +94,18 @@ hrpsys_gazebo_configuration:
     RLEG_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
     RLEG_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
     RLEG_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    L_INDEXMP_R:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_INDEXMP_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_INDEXPIP_R:  {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_MIDDLEPIP_R: {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_THUMBCM_Y:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_THUMBCM_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXMP_R:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXMP_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXPIP_R:  {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_MIDDLEPIP_R: {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_THUMBCM_Y:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_THUMBCM_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
 
   force_torque_sensors:
     - rfsensor

--- a/hrpsys_gazebo_tutorials/config/HRP2JSKNTS.yaml
+++ b/hrpsys_gazebo_tutorials/config/HRP2JSKNTS.yaml
@@ -11,7 +11,7 @@ hrpsys_gazebo_configuration:
 ### name of robot (using for namespace)
   robotname: HRP2JSKNTS
 ### joint_id (order) conversion from gazebo to hrpsys, joint_id_list[gazebo_id] := hrpsys_id
-  joint_id_list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33]
+  joint_id_list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45]
 ### joints : list used in gazebo, sizeof(joint_id_list) == sizeof(joints)
   joints:
     - RLEG_JOINT0
@@ -39,6 +39,7 @@ hrpsys_gazebo_configuration:
     - RARM_JOINT4
     - RARM_JOINT5
     - RARM_JOINT6
+    - RARM_JOINT7
     - LARM_JOINT0
     - LARM_JOINT1
     - LARM_JOINT2
@@ -46,6 +47,19 @@ hrpsys_gazebo_configuration:
     - LARM_JOINT4
     - LARM_JOINT5
     - LARM_JOINT6
+    - LARM_JOINT7
+    - L_THUMBCM_Y
+    - L_THUMBCM_P
+    - L_INDEXMP_R
+    - L_INDEXMP_P
+    - L_INDEXPIP_R
+    - L_MIDDLEPIP_R
+    - R_THUMBCM_Y
+    - R_THUMBCM_P
+    - R_INDEXMP_R
+    - R_INDEXMP_P
+    - R_INDEXPIP_R
+    - R_MIDDLEPIP_R
 ## jointid:
   gains:
     CHEST_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
@@ -80,6 +94,18 @@ hrpsys_gazebo_configuration:
     RLEG_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
     RLEG_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
     RLEG_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    L_INDEXMP_R:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_INDEXMP_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_INDEXPIP_R:  {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_MIDDLEPIP_R: {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_THUMBCM_Y:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_THUMBCM_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXMP_R:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXMP_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXPIP_R:  {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_MIDDLEPIP_R: {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_THUMBCM_Y:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_THUMBCM_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
 
   force_torque_sensors:
     - rfsensor

--- a/hrpsys_ros_bridge_tutorials/models/hrp2jsk.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/hrp2jsk.yaml
@@ -124,6 +124,7 @@ replace_xmls:
       sub_attribute_value: package://hrpsys_ros_bridge_tutorials/models/HRP2JSK_meshes/LLEG_LINK5_mesh.dae
     replaced_xml: '<collision>\n      <origin xyz="0.015 0.010 -0.08" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.240 0.138 0.07"/></geometry></collision>'
   - match_rule:
+      tag: limit
       attribute_name: velocity
       attribute_value: 0.5
     replaced_attribute_value: 10.0

--- a/hrpsys_ros_bridge_tutorials/models/hrp2jsknt.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/hrp2jsknt.yaml
@@ -180,10 +180,12 @@ replace_xmls:
       attribute_value: RLEG_LINK6
     replaced_xml: '<gazebo reference="RLEG_LINK6">\n    <kp>1400000.0</kp>\n    <kd>280.0</kd>\n    <mu1>1.5</mu1>\n    <mu2>1.5</mu2>\n    <fdir1>1 0 0</fdir1>\n    <maxVel>10.0</maxVel>\n    <minDepth>0.00</minDepth>\n  </gazebo>'
   - match_rule:
+      tag: limit
       attribute_name: velocity
       attribute_value: 0.5
     replaced_attribute_value: 10.0
   - match_rule:
+      tag: limit
       attribute_name: effort
       attribute_value: 100
     replaced_attribute_value: 1000

--- a/hrpsys_ros_bridge_tutorials/models/hrp2jsknts.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/hrp2jsknts.yaml
@@ -181,10 +181,12 @@ replace_xmls:
       attribute_value: RLEG_LINK6
     replaced_xml: '<gazebo reference="RLEG_LINK6">\n    <kp>1400000.0</kp>\n    <kd>280.0</kd>\n    <mu1>1.5</mu1>\n    <mu2>1.5</mu2>\n    <fdir1>1 0 0</fdir1>\n    <maxVel>10.0</maxVel>\n    <minDepth>0.00</minDepth>\n  </gazebo>'
   - match_rule:
+      tag: limit
       attribute_name: velocity
       attribute_value: 0.5
     replaced_attribute_value: 10.0
   - match_rule:
+      tag: limit
       attribute_name: effort
       attribute_value: 100
     replaced_attribute_value: 1000

--- a/hrpsys_ros_bridge_tutorials/models/jaxon.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/jaxon.yaml
@@ -157,14 +157,15 @@ replace_xmls:
       sub_tag: mesh
       sub_attribute_name: filename
       sub_attribute_value: package://hrpsys_ros_bridge_tutorials/models/JAXON_meshes/RLEG_LINK5_mesh.dae
-    replaced_xml: '<collision>\n      <origin xyz="0.015 -0.010 -0.08" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.240 0.138 0.07"/></geometry></collision>'
+    replaced_xml: '<collision>\n      <origin xyz="0.015 -0.010 -0.08" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.240 0.138 0.01"/></geometry></collision>'
   - match_rule:
       tag: collision
       sub_tag: mesh
       sub_attribute_name: filename
       sub_attribute_value: package://hrpsys_ros_bridge_tutorials/models/JAXON_meshes/LLEG_LINK5_mesh.dae
-    replaced_xml: '<collision>\n      <origin xyz="0.015 0.010 -0.08" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.240 0.138 0.07"/></geometry></collision>'
+    replaced_xml: '<collision>\n      <origin xyz="0.015 0.010 -0.08" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.240 0.138 0.01"/></geometry></collision>'
   - match_rule:
+      tag: limit
       attribute_name: velocity
       attribute_value: 0.5
     replaced_attribute_value: 10.0

--- a/hrpsys_ros_bridge_tutorials/models/staro.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/staro.yaml
@@ -134,22 +134,22 @@ replace_xmls:
       sub_tag: mesh
       sub_attribute_name: filename
       sub_attribute_value: package://hrpsys_ros_bridge_tutorials/models/STARO_meshes/RLEG_LINK5_mesh.dae
-    replaced_xml: '<collision>\n      <origin xyz="0.015 -0.010 -0.0709961" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.23 0.13 0.05" />'
+    replaced_xml: '<collision>\n      <origin xyz="0.015 -0.010 -0.0709961" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.23 0.13 0.05" /> </geometry> </collision>'
   - match_rule:
       tag: collision
       sub_tag: mesh
       sub_attribute_name: filename
       sub_attribute_value: package://hrpsys_ros_bridge_tutorials/models/STARO_meshes/LLEG_LINK5_mesh.dae
-    replaced_xml: '<collision>\n      <origin xyz="0.015 0.010 -0.0709961" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.23 0.13 0.05" />'
+    replaced_xml: '<collision>\n      <origin xyz="0.015 0.010 -0.0709961" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.23 0.13 0.05" />  </geometry> </collision>'
   - match_rule:
       tag: collision
       sub_tag: mesh
       sub_attribute_name: filename
       sub_attribute_value: package://hrpsys_ros_bridge_tutorials/models/STARO_meshes/BODY_mesh.dae
-    replaced_xml: '<collision>\n      <origin xyz="0 0 0.145" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.235 0.5 0.29" />'
+    replaced_xml: '<collision>\n      <origin xyz="0 0 0.145" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.235 0.5 0.29" />  </geometry> </collision>'
   - match_rule:
       tag: collision
       sub_tag: mesh
       sub_attribute_name: filename
       sub_attribute_value: package://hrpsys_ros_bridge_tutorials/models/STARO_meshes/CHEST_LINK1_mesh.dae
-    replaced_xml: '<collision>\n      <origin xyz="-0.05 0 -0.01" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.18 0.55 0.16" />'
+    replaced_xml: '<collision>\n      <origin xyz="-0.05 0 -0.01" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.18 0.55 0.16" />  </geometry> </collision>'

--- a/hrpsys_ros_bridge_tutorials/models/staro.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/staro.yaml
@@ -153,4 +153,3 @@ replace_xmls:
       sub_attribute_name: filename
       sub_attribute_value: package://hrpsys_ros_bridge_tutorials/models/STARO_meshes/CHEST_LINK1_mesh.dae
     replaced_xml: '<collision>\n      <origin xyz="-0.05 0 -0.01" rpy="0 -0 0"/>\n      <geometry>\n        <box size="0.18 0.55 0.16" />'
-b


### PR DESCRIPTION

1. Add missing specification about xml replacement rule for gazebo model
2. Fix syntax of staro yaml
3. Fix the number of joints controlled via hrpsys because now robot and
hands are integrated into one robot model