### PR TITLE
Jaxon in gazebo using real urdf model

### DIFF
--- a/hrpsys_gazebo_tutorials/robot_models/JAXON/JAXON.urdf.xacro
+++ b/hrpsys_gazebo_tutorials/robot_models/JAXON/JAXON.urdf.xacro
@@ -1,5 +1,180 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="JAXON" >
   <xacro:include filename="$(find hrpsys_ros_bridge_tutorials)/models/JAXON_WH_SENSORS.urdf" />
+
+  <!-- for multisense -->
+  <gazebo reference="head_hokuyo_frame">
+    <sensor type="gpu_ray" name="head_hokuyo_sensor">
+      <pose>0 0 0 0 0 0</pose>
+      <visualize>false</visualize>
+      <update_rate>40</update_rate>
+      <ray>
+        <scan>
+          <horizontal>
+            <samples>1081</samples>
+            <resolution>1</resolution>
+            <min_angle>-2.356194</min_angle>
+            <max_angle>2.356194</max_angle>
+          </horizontal>
+        </scan>
+        <range>
+          <min>0.10</min>
+          <max>30.0</max>
+          <resolution>0.01</resolution>
+        </range>
+        <noise>
+          <type>gaussian</type>
+          <!-- Noise parameters based on published spec for Hokuyo laser
+               achieving "+-30mm" accuracy at range < 10m.  A mean of 0.0m and
+               stddev of 0.01m will put 99.7% of samples within 0.03m of the true
+               reading. -->
+          <mean>0.0</mean>
+          <stddev>0.01</stddev>
+        </noise>
+      </ray>
+      <plugin name="gazebo_ros_head_hokuyo_controller" filename="libgazebo_ros_gpu_laser.so">
+        <topicName>/multisense/lidar_scan</topicName>
+        <frameName>head_hokuyo_frame</frameName>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <gazebo reference="left_camera_frame">
+    <sensor type="multicamera" name="stereo_camera">
+      <!-- see MultiSenseSLPlugin.h for available modes -->
+      <update_rate>10.0</update_rate>
+      <camera name="left">
+        <!-- Spec sheet says 80deg X 45deg @ 1024x544pix.  Based on feedback
+             from teams, we're instead doing 80deg X 80deg @ 800x800pix. -->
+        <horizontal_fov>1.3962634</horizontal_fov>
+        <image>
+          <width>1024</width>
+          <height>544</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+        <noise>
+          <type>gaussian</type>
+          <!-- Noise is sampled independently per pixel on each frame.  
+               That pixel's noise value is added to each of its color
+               channels, which at that point lie in the range [0,1].
+               The stddev value of 0.007 is based on experimental data 
+               from a camera in a Sandia hand pointed at a static scene
+               in a couple of different lighting conditions.  -->
+          <mean>0.0</mean>
+          <stddev>0.007</stddev>
+        </noise>
+      </camera>
+      <camera name="right">
+        <pose>0 -0.07 0 0 0 0</pose>
+        <!-- Spec sheet says 80deg X 45deg @ 1024x544pix. -->
+        <horizontal_fov>1.3962634</horizontal_fov>
+        <image>
+          <width>1024</width>
+          <height>544</height>
+          <format>R8G8B8</format>
+        </image>
+        <clip>
+          <near>0.02</near>
+          <far>300</far>
+        </clip>
+        <noise>
+          <type>gaussian</type>
+          <!-- Noise is sampled independently per pixel on each frame.  
+               That pixel's noise value is added to each of its color
+               channels, which at that point lie in the range [0,1].
+               The stddev value of 0.007 is based on experimental data 
+               from a camera in a Sandia hand pointed at a static scene
+               in a couple of different lighting conditions.  -->
+          <mean>0.0</mean>
+          <stddev>0.007</stddev>
+        </noise>
+      </camera>
+      <plugin name="stereo_camera_controller" filename="libgazebo_ros_multicamera.so">
+        <alwaysOn>true</alwaysOn>
+        <updateRate>0.0</updateRate>
+        <cameraName>multisense/camera</cameraName>
+        <imageTopicName>image_raw</imageTopicName>
+        <cameraInfoTopicName>camera_info</cameraInfoTopicName>
+        <frameName>left_camera_optical_frame</frameName>
+        <!--<rightFrameName>right_camera_optical_frame</rightFrameName>-->
+        <hackBaseline>0.07</hackBaseline>
+        <distortionK1>0.0</distortionK1>
+        <distortionK2>0.0</distortionK2>
+        <distortionK3>0.0</distortionK3>
+        <distortionT1>0.0</distortionT1>
+        <distortionT2>0.0</distortionT2>
+      </plugin>
+    </sensor>
+  </gazebo>
+  <link name="head_imu_link">
+    <inertial>
+      <mass value="1e-5" />
+      <!-- collocate with parent link and remove mass from it -->
+      <origin xyz="-0.122993 0.035033383 0.02774" rpy="0 0 0" />
+      <inertia ixx="1e-6" ixy="0" ixz="0" iyy="1e-6" iyz="0" izz="1e-6" />
+    </inertial>
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0"/>
+      <geometry>
+        <box size="0.01 0.01 0.01"/>
+      </geometry>
+    </visual>
+  </link>
+  <joint name="head_imu_joint" type="fixed">
+    <parent link="head"/>
+    <child link="head_imu_link"/>
+    <!-- putting it at the same z-level as the stereo -->
+    <origin xyz="-0.0475 0.035 0.0" rpy="0 0 0"/>
+  </joint>
+  <gazebo reference="head_imu_link">
+    <!-- this is expected to be reparented to head with appropriate offset
+         when head_imu_link is reduced by fixed joint reduction -->
+    <!-- todo: this is working with gazebo 1.4, need to write a unit test -->
+    <sensor name="head_imu_sensor" type="imu">
+      <always_on>1</always_on>
+      <update_rate>1000.0</update_rate>
+      <imu>
+        <noise>
+          <type>gaussian</type>
+          <!-- Noise parameters from Boston Dynamics
+               (http://gazebosim.org/wiki/Sensor_noise):
+                 rates (rad/s): mean=0, stddev=2e-4
+                 accels (m/s/s): mean=0, stddev=1.7e-2
+                 rate bias (rad/s): 5e-6 - 1e-5
+                 accel bias (m/s/s): 1e-1
+               Experimentally, simulation provide rates with noise of
+               about 1e-3 rad/s and accels with noise of about 1e-1 m/s/s.
+               So we don't expect to see the noise unless number of inner iterations
+               are increased.
+
+               We will add bias.  In this model, bias is sampled once for rates
+               and once for accels at startup; the sign (negative or positive)
+               of each bias is then switched with equal probability.  Thereafter,
+               the biases are fixed additive offsets.  We choose
+               bias means and stddevs to produce biases close to the provided
+               data. -->
+          <rate>
+            <mean>0.0</mean>
+            <stddev>2e-4</stddev>
+            <bias_mean>0.0000075</bias_mean>
+            <bias_stddev>0.0000008</bias_stddev>
+          </rate>
+          <accel>
+            <mean>0.0</mean>
+            <stddev>1.7e-2</stddev>
+            <bias_mean>0.1</bias_mean>
+            <bias_stddev>0.001</bias_stddev>
+          </accel>
+        </noise>
+      </imu>
+    </sensor>
+  </gazebo>
+  <gazebo>
+    <plugin filename="libJskMultiSenseSLPlugin.so" name="multisense_plugin"/>
+  </gazebo>
+
   <!-- add IOB plugin -->
   <gazebo>
     <plugin filename="libIOBPlugin.so" name="hrpsys_gazebo_plugin" >

--- a/hrpsys_ros_bridge_tutorials/models/jaxon.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/jaxon.yaml
@@ -169,3 +169,18 @@ replace_xmls:
       attribute_name: velocity
       attribute_value: 0.5
     replaced_attribute_value: 10.0
+  - match_rule:
+      tag: link
+      attribute_name: name
+      attribute_value: left_camera_optical_frame
+    replaced_xml: '<link name="left_camera_optical_frame">\n		<inertial>\n			<mass value="0.1"/>\n			<origin xyz="0 0 0"/>\n			<inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>\n		</inertial>\n	</link>'
+  - match_rule:
+      tag: link
+      attribute_name: name
+      attribute_value: motor
+    replaced_xml: '<link name="motor">\n		<inertial>\n			<mass value="0.1"/>\n			<origin xyz="0 0 0"/>\n			<inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>\n		</inertial>\n	</link>'
+  - match_rule:
+      tag: link
+      attribute_name: name
+      attribute_value: spindle
+    replaced_xml: '<link name="spindle">\n		<inertial>\n			<mass value="0.1"/>\n			<origin xyz="0 0 0"/>\n			<inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>\n		</inertial>\n	</link>'

--- a/hrpsys_ros_bridge_tutorials/models/jaxon.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/jaxon.yaml
@@ -184,3 +184,18 @@ replace_xmls:
       attribute_name: name
       attribute_value: spindle
     replaced_xml: '<link name="spindle">\n		<inertial>\n			<mass value="0.1"/>\n			<origin xyz="0 0 0"/>\n			<inertia ixx="0.001" ixy="0.0" ixz="0.0" iyy="0.001" iyz="0.0" izz="0.001"/>\n		</inertial>\n	</link>'
+  - match_rule:
+      tag: joint
+      attribute_name: name
+      attribute_value: left_camera_optical_joint
+    replaced_xml: '<joint name="left_camera_optical_joint" type="continuous">\n		<parent link="left_camera_optical_frame"/>\n		<child link="motor"/>\n        <origin xyz="0.031 -0.081 -0.002" rpy="0.009 -0.002 -1.044"/>\n	</joint>'
+  - match_rule:
+      tag: joint
+      attribute_name: name
+      attribute_value: motor_joint
+    replaced_xml: '<joint name="motor_joint" type="continuous">\n		<parent link="motor"/>\n		<child link="spindle"/>\n        <origin xyz="0.0 0.0 0.0" rpy="0.0 0.0 0.0"/>\n		<axis xyz="0 0 1"/>\n	</joint>'
+  - match_rule:
+      tag: joint
+      attribute_name: name
+      attribute_value: spindle_joint
+    replaced_xml: '<joint name="spindle_joint" type="continuous">\n		<parent link="spindle"/>\n		<child link="hokuyo_link"/>\n        <origin xyz="0.001 0.020 0.0" rpy="0.001 -0.012 -0.000"/>\n	</joint>'


### PR DESCRIPTION
JAXON実機のurdfをgazebo上で使うためのurdf側の変更です. https://github.com/jsk-ros-pkg/trans_system/pull/454 が必要です.
ひとまずはJAXONのみの変更になっています.
変更点は以下です.

1. gazebo用urdf内でのpluginのload
  gazeboでloadされるurdfにmultisense関連のpluginを記述しました.
  内容はmultisense_sl_v4.urdfを参考にしています.
  https://github.com/jsk-ros-pkg/trans_system/pull/454 のJskMultisenseSLPluginを使用しています.

2. multisense関連のリンク定義の変更
  gazeboではリンクにinertialタグがないと有効なリンクとみなされないようなので, inertialタグを追加しました. 値はleft_optical_frameの値を参考にしています.
  cf. http://gazebosim.org/tutorials/?tut=ros_urdf

3. multisense関連の関節定義の変更
  元のurdfではleft_camera_optical_frame -> motor -> spindle -> hokuyo_linkの間の座標変換が定義されていないため, gazeboで元のモデルを表示するとleft_camera_optical_frameにhokuyo_linkが埋まります.
  実機ではこの座標変換はmultisense_driverがtfとして出していますが, gazebo上ではtfに加えてgazebo内でのリンク位置を決めるための座標が必要になります. 
  今回はJAXON_RED実機のtfに出ている値をそのまま書き込んでいます.
  fixedでないリンクはjoint_statesが出ない限りrobot_state_publisherがtfを吐かないため, jointのoriginを定義していても実機ではmultisense_driverのtfのみが出て影響は無い(はず)です.
  記載されいてるoriginの値が実機のmultisenseでtf上に反映されず, multisense_driverのtfと干渉しないことまでは確認しています.
  