### PR TITLE
Samplerobot wh sensors

### DIFF
--- a/hrpsys_gazebo_tutorials/robot_models/SampleRobot/SampleRobot.urdf.xacro
+++ b/hrpsys_gazebo_tutorials/robot_models/SampleRobot/SampleRobot.urdf.xacro
@@ -1,5 +1,5 @@
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro" name="SampleRobot" >
-  <xacro:include filename="$(find hrpsys_ros_bridge_tutorials)/models//SampleRobot.urdf" />
+  <xacro:include filename="$(find hrpsys_ros_bridge_tutorials)/models/SampleRobot_WH_SENSORS.urdf" />
   <!-- add IOB plugin -->
   <gazebo>
     <plugin filename="libIOBPlugin.so" name="hrpsys_gazebo_plugin" >

--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -599,6 +599,10 @@ if(EXISTS ${jsk_models_MODEL_DIR}/JAXON_RED/l_hand_attached_link.dae)
 endif()
 endif()
 
+# for SampleRobot
+attach_sensor_and_endeffector_to_hrp2jsk_urdf(SampleRobot SampleRobot.urdf
+  SampleRobot_WH_SENSORS.urdf samplerobot.yaml)
+
 # Define dependency for urdf conversion to avoid parallel cmake problem (https://github.com/start-jsk/rtmros_tutorials/issues/373)
 if (DEFINED compile_urdf_robots)
   add_custom_target(all_urdf_model_generate ALL DEPENDS ${compile_urdf_robots})

--- a/hrpsys_ros_bridge_tutorials/models/samplerobot.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/samplerobot.yaml
@@ -50,8 +50,10 @@ rarm-end-coords:
   parent    : RARM_LINK6
 lleg-end-coords:
   translate : [0.00, 0, -0.07]
+  parent    : LLEG_LINK6
 rleg-end-coords:
   translate : [0.00, 0, -0.07]
+  parent    : RLEG_LINK6
 head-end-coords:
   translate : [0.08, 0, 0.13]
   rotate    : [0, 1, 0, 90]
@@ -92,10 +94,12 @@ replace_xmls:
       attribute_value: RLEG_LINK6
     replaced_xml: '<gazebo reference="RLEG_LINK6">\n    <kp>1000000.0</kp>\n    <kd>100.0</kd>\n    <mu1>1.5</mu1>\n    <mu2>1.5</mu2>\n    <fdir1>1 0 0</fdir1>\n    <maxVel>10.0</maxVel>\n    <minDepth>0.00</minDepth>\n  </gazebo>'
   - match_rule:
+      tag: limit
       attribute_name: effort
       attribute_value: 100
     replaced_attribute_value: 200
   - match_rule:
+      tag: limit
       attribute_name: velocity
       attribute_value: 0.5
     replaced_attribute_value: 6.0

--- a/hrpsys_ros_bridge_tutorials/models/samplerobot.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/samplerobot.yaml
@@ -103,3 +103,8 @@ replace_xmls:
       attribute_name: velocity
       attribute_value: 0.5
     replaced_attribute_value: 6.0
+  - match_rule:
+      tag: joint
+      attribute_name: type
+      attribute_value: continuous
+    replaced_attribute_value: revolute


### PR DESCRIPTION
https://github.com/start-jsk/rtmros_tutorials/pull/380 の続きでgazeboのSampleRobotが脱力してしまう問題ですが，
https://github.com/start-jsk/rtmros_tutorials/pull/365 で 関節のtypeをcontinuousからrevoluteに変える変更が引き継がれておらず，
revoluteにするようにしたら解決しました．