### PR TITLE
Comment out deprecated test using euslisp + samplerobot because latest tests are moved to hrpsys_ros_bridge

### DIFF
--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -620,7 +620,7 @@ install(CODE
 
 add_rostest(test/test_hrpsys_pa10.launch)
 add_rostest(test/test_hrpsys_samplerobot.launch)
-add_rostest(test/samplerobot_hrpsys-ros-bridge_test.launch)
+#add_rostest(test/samplerobot_hrpsys-ros-bridge_test.launch)
 if(${hrp2_models_FOUND})
   add_rostest(test/test_robot_model.launch)
 endif()


### PR DESCRIPTION
Comment out deprecated test using euslisp + samplerobot because latest tests are moved to hrpsys_ros_bridge.