### PR TITLE
[hrpsys_ros_bridge_tutorials] Calibrate multisense external parameters of JAXON for new head

### DIFF
--- a/hrpsys_ros_bridge_tutorials/models/JAXON.urdf.xacro
+++ b/hrpsys_ros_bridge_tutorials/models/JAXON.urdf.xacro
@@ -56,10 +56,11 @@
     <parent link="HEAD_LINK1" />
     <child  link="head_root" />
     <!-- <origin rpy="-0.01 0.01 0.017" xyz="0.08 0.01 0.045"/> --> <!-- For leg -->
-    <origin rpy="-0.01 0.035 -0.005" xyz="0.085 0.01 0.065"/>
     <!-- <rigin rpy="-0.01 0.02 0.017" xyz="0.07 -0.01 0.045"/> old -->
     <!-- <origin rpy="-0.01 0.01 0.017" xyz="0.09 0.01 0.055"/>  --><!--middle-->
-    <!-- <origin rpy="-0.01 0.01 0.017" xyz="0.10 0.01 0.065"/> --> <!-- For hand -->
+    <!-- <origin rpy="-0.01 0.01 0.017" xyz="0.10 0.01 0.065"/> --> <!-- For hand --> 
+    <!-- <origin rpy="-0.01 0.035 -0.005" xyz="0.085 0.01 0.065"/> --> <!-- old head in 20151022 -->
+    <origin rpy="-0.004 0.275 -0.01" xyz="0.1 0.01 0.085"/> <!-- new head in 20151022 -->
   </joint>
   <!-- HAND -->
   <xacro:include filename="$(find jaxon_description)/urdf/thk_hand003.urdf.xacro" />


### PR DESCRIPTION
a. Laser pointclouds with caliblated multisense of JAXON. Blue points are within 30mm from the ground plane (based on lleg_end_coords)
![20151022-jaxon-multisense-calib-plane](https://cloud.githubusercontent.com/assets/5397422/10665363/9b4ed1f2-7905-11e5-8a27-98600c60b4cc.png)

b. Stereo pointclouds with caliblated multisense of JAXON.
![20151022-jaxon-multisense-calib-hand](https://cloud.githubusercontent.com/assets/5397422/10665367/a290bf02-7905-11e5-9d85-4648a53fdc90.png)
