### PR TITLE
Add sample4legrobot

### DIFF
--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -68,6 +68,25 @@ else()
   message(FATAL_ERROR "${OPENHRP_SAMPLE_DIR}/model/sample1.wrl not found")
 endif(EXISTS ${OPENHRP_SAMPLE_DIR}/model/sample1.wrl)
 
+if(EXISTS ${OPENHRP_SAMPLE_DIR}/model/sample_4leg_robot.wrl)
+compile_openhrp_model(
+  ${OPENHRP_SAMPLE_DIR}/model/sample_4leg_robot.wrl Sample4LegRobot
+  --conf-dt-option "0.002"
+  --simulation-timestep-option "0.002"
+  --conf-file-option "abc_leg_offset: 0,0.19,0"
+  --conf-file-option "abc_stride_parameter: 0.15,0.05,10"
+  --conf-file-option "end_effectors: rleg,RLEG_JOINT5,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT5,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, rarm,RARM_JOINT5,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, larm,LARM_JOINT5,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0,"
+  --conf-file-option "pdgains_sim_file_name: ${hrpsys_PREFIX}/share/hrpsys/samples/Sample4LegRobot/Sample4LegRobot.PDgain.dat"
+  --robothardware-conf-file-option "pdgains.file_name: ${PROJECT_SOURCE_DIR}/models/PDgains.sav"
+  )
+else()
+  get_cmake_property(_variableNames VARIABLES)
+  foreach (_variableName ${_variableNames})
+    message(STATUS "${_variableName}=${${_variableName}}")
+  endforeach()
+  message(FATAL_ERROR "${OPENHRP_SAMPLE_DIR}/model/sample_4leg_robot.wrl not found")
+endif(EXISTS ${OPENHRP_SAMPLE_DIR}/model/sample_4leg_robot.wrl)
+
 # collada_robots
 # webots_simulator
 # yaskawa
@@ -401,6 +420,7 @@ generate_default_launch_eusinterface_files(
   TESTMDOFARM
   "--no-euslisp")
 generate_default_launch_eusinterface_files("$(find openhrp3)/share/OpenHRP-3.1/sample/model/sample1.wrl" hrpsys_ros_bridge_tutorials SampleRobot "--use-robot-hrpsys-config")
+generate_default_launch_eusinterface_files("$(find openhrp3)/share/OpenHRP-3.1/sample/model/sample_4leg_robot.wrl" hrpsys_ros_bridge_tutorials Sample4LegRobot "--use-robot-hrpsys-config")
 
 ################################
 ## Generate and modify .urdf files

--- a/hrpsys_ros_bridge_tutorials/euslisp/sample4legrobot-interface.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/sample4legrobot-interface.l
@@ -1,0 +1,16 @@
+(load "package://hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l")
+(require :sample4legrobot "package://hrpsys_ros_bridge_tutorials/models/sample4legrobot.l")
+
+(defclass sample4legrobot-interface
+  :super rtm-ros-robot-interface
+  :slots ())
+(defmethod sample4legrobot-interface
+  (:init (&rest args)
+         (send-super* :init :robot sample4legrobot-robot args)))
+
+(defun sample4legrobot-init (&rest args)
+  (if (not (boundp '*ri*))
+      (setq *ri* (instance* sample4legrobot-interface :init args)))
+  (if (not (boundp '*s4lr*))
+      (setq *s4lr* (instance sample4legrobot-robot :init)))
+  )

--- a/hrpsys_ros_bridge_tutorials/models/sample4legrobot.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/sample4legrobot.yaml
@@ -1,0 +1,57 @@
+##
+## - collada_joint_name : euslisp_joint_name (start with :)
+##
+
+rleg:
+  - RLEG_JOINT0  : rleg-crotch-y
+  - RLEG_JOINT1  : rleg-crotch-r
+  - RLEG_JOINT2  : rleg-crotch-p
+  - RLEG_JOINT3  : rleg-knee-p
+  - RLEG_JOINT4  : rleg-ankle-p
+  - RLEG_JOINT5  : rleg-ankle-r
+lleg:
+  - LLEG_JOINT0  : lleg-crotch-y
+  - LLEG_JOINT1  : lleg-crotch-r
+  - LLEG_JOINT2  : lleg-crotch-p
+  - LLEG_JOINT3  : lleg-knee-p
+  - LLEG_JOINT4  : lleg-ankle-p
+  - LLEG_JOINT5  : lleg-ankle-r
+rarm:
+  - RARM_JOINT0  : rarm-crotch-y
+  - RARM_JOINT1  : rarm-crotch-r
+  - RARM_JOINT2  : rarm-crotch-p
+  - RARM_JOINT3  : rarm-knee-p
+  - RARM_JOINT4  : rarm-ankle-p
+  - RARM_JOINT5  : rarm-ankle-r
+larm:
+  - LARM_JOINT0  : larm-crotch-y
+  - LARM_JOINT1  : larm-crotch-r
+  - LARM_JOINT2  : larm-crotch-p
+  - LARM_JOINT3  : larm-knee-p
+  - LARM_JOINT4  : larm-ankle-p
+  - LARM_JOINT5  : larm-ankle-r
+
+
+##
+## end-coords
+##
+larm-end-coords:
+  translate : [0, 0, -0.07]
+  parent    : LARM_LINK5
+rarm-end-coords:
+  translate : [0, 0, -0.07]
+  parent    : RARM_LINK5
+lleg-end-coords:
+  translate : [0, 0, -0.07]
+rleg-end-coords:
+  translate : [0, 0, -0.07]
+
+##
+## reset-pose
+##
+angle-vector:
+  reset-pose : [-0.004457, -21.6929, -0.01202, 47.6723, -25.93, 0.014025, # rleg
+                -0.004457, -21.6929, -0.01202, 47.6723, -25.93, 0.014025, # lleg
+                -0.004457, -21.6929, -0.01202, 47.6723, -25.93, 0.014025, # rarm
+                -0.004457, -21.6929, -0.01202, 47.6723, -25.93, 0.014025  # larm
+                ]

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/sample4legrobot_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/sample4legrobot_hrpsys_config.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python
+
+pkg = 'hrpsys'
+import imp
+imp.find_module(pkg)
+
+from hrpsys.hrpsys_config import *
+import OpenHRP
+
+from sample_hrpsys_config import *
+
+if __name__ == '__main__':
+    hcf = SampleHrpsysConfigurator("Sample4LegRobot")
+    if len(sys.argv) > 2 :
+        hcf.init(sys.argv[1], sys.argv[2])
+    elif len(sys.argv) > 1 :
+        hcf.init(sys.argv[1])
+    else :
+        hcf.init()

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/sample_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/sample_hrpsys_config.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+pkg = 'hrpsys'
+import imp
+imp.find_module(pkg)
+
+from hrpsys.hrpsys_config import *
+import OpenHRP
+
+class SampleHrpsysConfigurator(HrpsysConfigurator):
+    def getRTCList (self):
+        return self.getRTCListUnstable()
+    def init (self, robotname="Robot", url=""):
+        HrpsysConfigurator.init(self, robotname, url)
+        print "initialize rtc parameters"
+        self.setStAbcParameters()
+
+    def defJointGroups (self):
+        if self.ROBOT_NAME == "SampleRobot":
+            rleg_6dof_group = ['rleg', ['RLEG_HIP_R', 'RLEG_HIP_P', 'RLEG_HIP_Y', 'RLEG_KNEE', 'RLEG_ANKLE_P', 'RLEG_ANKLE_R']]
+            lleg_6dof_group = ['lleg', ['LLEG_HIP_R', 'LLEG_HIP_P', 'LLEG_HIP_Y', 'LLEG_KNEE', 'LLEG_ANKLE_P', 'LLEG_ANKLE_R']]
+            torso_group = ['torso', ['WAIST_P', 'WAIST_R', 'CHEST']]
+            head_group = ['head', []]
+            rarm_group = ['rarm', ['RARM_SHOULDER_P', 'RARM_SHOULDER_R', 'RARM_SHOULDER_Y', 'RARM_ELBOW', 'RARM_WRIST_Y', 'RARM_WRIST_P', 'RARM_WRIST_R']]
+            larm_group = ['larm', ['LARM_SHOULDER_P', 'LARM_SHOULDER_R', 'LARM_SHOULDER_Y', 'LARM_ELBOW', 'LARM_WRIST_Y', 'LARM_WRIST_P', 'LARM_WRIST_R']]
+            self.Groups = [rleg_6dof_group, lleg_6dof_group, torso_group, head_group, rarm_group, larm_group]
+        elif self.ROBOT_NAME == "Sample4LegRobot":
+            rleg_6dof_group = ['rleg', ['RLEG_JOINT0', 'RLEG_JOINT1', 'RLEG_JOINT2', 'RLEG_JOINT3', 'RLEG_JOINT4', 'RLEG_JOINT5']]
+            lleg_6dof_group = ['lleg', ['LLEG_JOINT0', 'LLEG_JOINT1', 'LLEG_JOINT2', 'LLEG_JOINT3', 'LLEG_JOINT4', 'LLEG_JOINT5']]
+            torso_group = ['torso', []]
+            head_group = ['head', []]
+            rarm_group = ['rarm', ['RARM_JOINT0', 'RARM_JOINT1', 'RARM_JOINT2', 'RARM_JOINT3', 'RARM_JOINT4', 'RARM_JOINT5']]
+            larm_group = ['larm', ['LARM_JOINT0', 'LARM_JOINT1', 'LARM_JOINT2', 'LARM_JOINT3', 'LARM_JOINT4', 'LARM_JOINT5']]
+            self.Groups = [rleg_6dof_group, lleg_6dof_group, torso_group, head_group, rarm_group, larm_group]
+
+    def setStAbcParameters (self):
+        # ST parameters
+        stp=self.st_svc.getParameter()
+        stp.st_algorithm=OpenHRP.StabilizerService.EEFMQP
+        #   eefm st params
+        stp.eefm_leg_inside_margin=71.12*1e-3
+        stp.eefm_leg_outside_margin=71.12*1e-3
+        stp.eefm_leg_front_margin=182.0*1e-3
+        stp.eefm_leg_rear_margin=72.0*1e-3
+        stp.eefm_k1=[-1.39899,-1.39899]
+        stp.eefm_k2=[-0.386111,-0.386111]
+        stp.eefm_k3=[-0.175068,-0.175068]
+        stp.eefm_rot_damping_gain=[[20*1.6*10, 20*1.6*10, 1e5]]*4 # Stiff parameter for simulation
+        stp.eefm_pos_damping_gain=[[3500*50, 3500*50, 3500*1.0*5]]*4 # Stiff parameter for simulation
+        if self.ROBOT_NAME == "Sample4LegRobot":
+            rleg_vertices = [OpenHRP.StabilizerService.TwoDimensionVertex(pos=[stp.eefm_leg_front_margin, stp.eefm_leg_inside_margin]),
+                             OpenHRP.StabilizerService.TwoDimensionVertex(pos=[stp.eefm_leg_front_margin, -1*stp.eefm_leg_outside_margin]),
+                             OpenHRP.StabilizerService.TwoDimensionVertex(pos=[-1*stp.eefm_leg_rear_margin, -1*stp.eefm_leg_outside_margin]),
+                             OpenHRP.StabilizerService.TwoDimensionVertex(pos=[-1*stp.eefm_leg_rear_margin, stp.eefm_leg_inside_margin])]
+            lleg_vertices = [OpenHRP.StabilizerService.TwoDimensionVertex(pos=[stp.eefm_leg_front_margin, stp.eefm_leg_outside_margin]),
+                             OpenHRP.StabilizerService.TwoDimensionVertex(pos=[stp.eefm_leg_front_margin, -1*stp.eefm_leg_inside_margin]),
+                             OpenHRP.StabilizerService.TwoDimensionVertex(pos=[-1*stp.eefm_leg_rear_margin, -1*stp.eefm_leg_inside_margin]),
+                             OpenHRP.StabilizerService.TwoDimensionVertex(pos=[-1*stp.eefm_leg_rear_margin, stp.eefm_leg_outside_margin])]
+            rarm_vertices = rleg_vertices
+            larm_vertices = lleg_vertices
+            stp.eefm_support_polygon_vertices_sequence = map (lambda x : OpenHRP.StabilizerService.SupportPolygonVertices(vertices=x), [lleg_vertices, rleg_vertices, larm_vertices, rarm_vertices])
+            stp.is_ik_enable = [True]*4
+            stp.is_feedback_control_enable = [True]*4
+            stp.is_zmp_calc_enable = [True]*4
+            stp.eefm_use_force_difference_control=False
+        #   tpcc st params
+        stp.k_tpcc_p=[0.2, 0.2]
+        stp.k_tpcc_x=[4.0, 4.0]
+        stp.k_brot_p=[0.0, 0.0]
+        stp.k_brot_tc=[0.1, 0.1]
+        self.st_svc.setParameter(stp)
+        # ABC parameters
+        abcp=self.abc_svc.getAutoBalancerParam()[1]
+        ggp=self.abc_svc.getGaitGeneratorParam()[1]
+        if self.ROBOT_NAME == "Sample4LegRobot":
+            abcp.leg_names = ['rleg', 'lleg', 'rarm', 'larm']
+            ggp.zmp_weight_map = [1.0]*4
+            ggp.default_step_height = 0.05
+        self.abc_svc.setAutoBalancerParam(abcp)
+        self.abc_svc.setGaitGeneratorParam(ggp)
+
+    def __init__(self, robotname=""):
+        self.ROBOT_NAME = robotname
+        HrpsysConfigurator.__init__(self)
+        self.defJointGroups()

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/sample_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/sample_hrpsys_config.py
@@ -48,6 +48,7 @@ class SampleHrpsysConfigurator(HrpsysConfigurator):
         stp.eefm_rot_damping_gain=[[20*1.6*10, 20*1.6*10, 1e5]]*4 # Stiff parameter for simulation
         stp.eefm_pos_damping_gain=[[3500*50, 3500*50, 3500*1.0*5]]*4 # Stiff parameter for simulation
         if self.ROBOT_NAME == "Sample4LegRobot":
+            stp.st_algorithm=OpenHRP.StabilizerService.EEFMQPCOP
             rleg_vertices = [OpenHRP.StabilizerService.TwoDimensionVertex(pos=[stp.eefm_leg_front_margin, stp.eefm_leg_inside_margin]),
                              OpenHRP.StabilizerService.TwoDimensionVertex(pos=[stp.eefm_leg_front_margin, -1*stp.eefm_leg_outside_margin]),
                              OpenHRP.StabilizerService.TwoDimensionVertex(pos=[-1*stp.eefm_leg_rear_margin, -1*stp.eefm_leg_outside_margin]),
@@ -75,7 +76,7 @@ class SampleHrpsysConfigurator(HrpsysConfigurator):
         if self.ROBOT_NAME == "Sample4LegRobot":
             abcp.leg_names = ['rleg', 'lleg', 'rarm', 'larm']
             ggp.zmp_weight_map = [1.0]*4
-            ggp.default_step_height = 0.05
+            ggp.default_step_height = 0.009
         self.abc_svc.setAutoBalancerParam(abcp)
         self.abc_svc.setGaitGeneratorParam(ggp)
 

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/samplerobot_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/samplerobot_hrpsys_config.py
@@ -7,50 +7,10 @@ imp.find_module(pkg)
 from hrpsys.hrpsys_config import *
 import OpenHRP
 
-class SampleRobotHrpsysConfigurator(HrpsysConfigurator):
-    def getRTCList (self):
-        return self.getRTCListUnstable()
-    def init (self, robotname="SampleRobot", url=""):
-        HrpsysConfigurator.init(self, robotname, url)
-        print "initialize rtc parameters"
-        self.setStAbcParameters()
-
-    def defJointGroups (self):
-        rleg_6dof_group = ['rleg', ['RLEG_HIP_R', 'RLEG_HIP_P', 'RLEG_HIP_Y', 'RLEG_KNEE', 'RLEG_ANKLE_P', 'RLEG_ANKLE_R']]
-        lleg_6dof_group = ['lleg', ['LLEG_HIP_R', 'LLEG_HIP_P', 'LLEG_HIP_Y', 'LLEG_KNEE', 'LLEG_ANKLE_P', 'LLEG_ANKLE_R']]
-        torso_group = ['torso', ['WAIST_P', 'WAIST_R', 'CHEST']]
-        head_group = ['head', []]
-        rarm_group = ['rarm', ['RARM_SHOULDER_P', 'RARM_SHOULDER_R', 'RARM_SHOULDER_Y', 'RARM_ELBOW', 'RARM_WRIST_Y', 'RARM_WRIST_P', 'RARM_WRIST_R']]
-        larm_group = ['larm', ['LARM_SHOULDER_P', 'LARM_SHOULDER_R', 'LARM_SHOULDER_Y', 'LARM_ELBOW', 'LARM_WRIST_Y', 'LARM_WRIST_P', 'LARM_WRIST_R']]
-        self.Groups = [rleg_6dof_group, lleg_6dof_group, torso_group, head_group, rarm_group, larm_group]
-
-    def setStAbcParameters (self):
-        # ST parameters
-        stp=self.st_svc.getParameter()
-        stp.st_algorithm=OpenHRP.StabilizerService.EEFMQP
-        #   eefm st params
-        stp.eefm_leg_inside_margin=71.12*1e-3
-        stp.eefm_leg_outside_margin=71.12*1e-3
-        stp.eefm_leg_front_margin=182.0*1e-3
-        stp.eefm_leg_rear_margin=72.0*1e-3
-        stp.eefm_k1=[-1.39899,-1.39899]
-        stp.eefm_k2=[-0.386111,-0.386111]
-        stp.eefm_k3=[-0.175068,-0.175068]
-        stp.eefm_rot_damping_gain=[[20*1.6*10, 20*1.6*10, 1e5]]*4 # Stiff parameter for simulation
-        stp.eefm_pos_damping_gain=[[3500*50, 3500*50, 3500*1.0*5]]*4 # Stiff parameter for simulation
-        #   tpcc st params
-        stp.k_tpcc_p=[0.2, 0.2]
-        stp.k_tpcc_x=[4.0, 4.0]
-        stp.k_brot_p=[0.0, 0.0]
-        stp.k_brot_tc=[0.1, 0.1]
-        self.st_svc.setParameter(stp)
-
-    def __init__(self, robotname=""):
-        HrpsysConfigurator.__init__(self)
-        self.defJointGroups()
+from sample_hrpsys_config import *
 
 if __name__ == '__main__':
-    hcf = SampleRobotHrpsysConfigurator()
+    hcf = SampleHrpsysConfigurator("SampleRobot")
     if len(sys.argv) > 2 :
         hcf.init(sys.argv[1], sys.argv[2])
     elif len(sys.argv) > 1 :


### PR DESCRIPTION
4脚練習用ロボットをhrpsys_ros_bridge_tutorialsに入れたいのですが，問題ないでしょうか？
（st/abcのパラメータがセットされた状態でeusから動かしたいため）

それに伴い，4脚練習用ロボット用のCMakeなどなどの追加以外に，他のロボットシリーズ（hrp2シリーズ / 浦田シリーズ）に沿って，

- samplerobot_hrpsys_config.py を sample_hrpsys_config.pyに改名
- samplerobot_hrpsys_config.py で sample_hrpsys_config.py を importするようにした
- sample4legrobot_hrpsys_config.py で sample_hrpsys_config.py を importするようにした

という変更を加えました．

以下動作確認コマンド

![a](https://cloud.githubusercontent.com/assets/4509039/10666211/29e51b06-790b-11e5-86a8-48dd192bf709.gif)


### launch hrpsys simulator

```bash
openhrp-project-generator `rospack find openhrp3`/share/OpenHRP-3.1/sample/model/sample_4leg_robot_bush.wrl `rospack find openhrp3`/share/OpenHRP-3.1/sample/model/longfloor.wrl --use-highgain-mode false --output /tmp/Sample4LegRobot_for_torquecontrol.xml --timeStep 0.001 --dt 0.002 --method RUNGE_KUTTA && export BUSH_CUSTOMIZER_CONFIG_PATH=`rospack find openhrp3`/../OpenHRP-3.1/customizer/sample_4leg_robot_bush_customizer_param.conf && rtmlaunch hrpsys_ros_bridge_tutorials sample4legrobot.launch PROJECT_FILE:=/tmp/Sample4LegRobot_for_torquecontrol.xml hrpsys_precreate_rtc:=PDcontroller USE_UNSTABLE_RTC:=true RUN_RVIZ:=false
```

### walk

```lisp
(progn
  (load "package://hrpsys_ros_bridge_tutorials/euslisp/sample4legrobot-interface.l")
  (setq *robot* (sample4legrobot-init))
  (send *ri* :angle-vector (send *robot* :reset-pose))
  (send *ri* :wait-interpolation)
  (send *ri* :start-auto-balancer :limbs '(:rleg :lleg :rarm :larm))
  (send *ri* :start-st)
  (send *ri* :set-foot-steps
        (list (list (make-coords :coords (send *robot* :lleg :end-coords :copy-worldcoords) :name :lleg)
                    (make-coords :coords (send *robot* :rarm :end-coords :copy-worldcoords) :name :rarm))
              (list (make-coords :coords (send (send *robot* :rleg :end-coords :copy-worldcoords) :translate #f(150 0 0)) :name :rleg)
                    (make-coords :coords (send (send *robot* :larm :end-coords :copy-worldcoords) :translate #f(150 0 0)) :name :larm))
              (list (make-coords :coords (send (send *robot* :lleg :end-coords :copy-worldcoords) :translate #f(300 0 0)) :name :lleg)
                    (make-coords :coords (send (send *robot* :rarm :end-coords :copy-worldcoords) :translate #f(300 0 0)) :name :rarm))
              (list (make-coords :coords (send (send *robot* :rleg :end-coords :copy-worldcoords) :translate #f(450 0 0)) :name :rleg)
                    (make-coords :coords (send (send *robot* :larm :end-coords :copy-worldcoords) :translate #f(450 0 0)) :name :larm))
              (list (make-coords :coords (send (send *robot* :lleg :end-coords :copy-worldcoords) :translate #f(450 0 0)) :name :lleg)
                    (make-coords :coords (send (send *robot* :rarm :end-coords :copy-worldcoords) :translate #f(450 0 0)) :name :rarm))
              ))
  )
```