### PR TITLE
modify default parameter for hrp2

### DIFF
--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/hrp2_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/hrp2_hrpsys_config.py
@@ -143,7 +143,7 @@ class JSKHRP2HrpsysConfigurator(HrpsysConfigurator):
         stp.eefm_k3=[-0.16200000000000001, -0.16200000000000001]
         # for estop
         stp.emergency_check_mode=OpenHRP.StabilizerService.CP;
-        stp.cp_check_margin=80*1e-3;
+        stp.cp_check_margin=20*1e-3;
         self.st_svc.setParameter(stp)
         # GG parameters
         gg=self.abc_svc.getGaitGeneratorParam()[1]
@@ -238,7 +238,7 @@ class JSKHRP2HrpsysConfigurator(HrpsysConfigurator):
         stp.eefm_k3=[-0.16200000000000001, -0.16200000000000001]
         # for estop
         stp.emergency_check_mode=OpenHRP.StabilizerService.CP;
-        stp.cp_check_margin=80*1e-3;
+        stp.cp_check_margin=20*1e-3;
         self.st_svc.setParameter(stp)
         # GG parameters
         gg=self.abc_svc.getGaitGeneratorParam()[1]
@@ -333,7 +333,7 @@ class JSKHRP2HrpsysConfigurator(HrpsysConfigurator):
         stp.eefm_k3=[-0.16200000000000001, -0.16200000000000001]
         # for estop
         stp.emergency_check_mode=OpenHRP.StabilizerService.CP;
-        stp.cp_check_margin=80*1e-3;
+        stp.cp_check_margin=20*1e-3;
         self.st_svc.setParameter(stp)
         # GG parameters
         gg=self.abc_svc.getGaitGeneratorParam()[1]


### PR DESCRIPTION
新しい転倒判定方法( https://github.com/fkanehiro/hrpsys-base/pull/857 )では，今の```cp_check_margin``` のデフォルト値では大きすぎるので変更しました．