### PR TITLE
[hrpsys_ros_bridge_tutorials/euslisp/jaxon_red-utils.l] fix JAXON_RED…

### DIFF
--- a/hrpsys_ros_bridge_tutorials/euslisp/jaxon_red-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/jaxon_red-utils.l
@@ -72,7 +72,9 @@
                         :init :link-list
                         :parent (send self l :end-coords)
                         :coords (send (send (send (send self l :end-coords :copy-worldcoords)
-                                                  :translate offset)
+                                                  :translate (cond ((eq l :rarm) (v- offset (float-vector 20 0 0))) ; based on real robot measurement
+                                                                   ((eq l :larm) (v- offset (float-vector 10 0 0))) ; based on real robot measurement
+                                                                   ))
                                             :rotate -pi/2 :y)
                                       :rotate (* sgn -pi/2) :z)
                         :name n))


### PR DESCRIPTION
… hand contact coodinates

まだマージしないでください．

スーパーテンポラリー（本当はend-coordsを治すべき）ですが，
JAXON_REDの接触点の位置を実機ベースの値に合わせました．

実機で確認したいので，まだマージしないでください．