### PR TITLE
Do not gen limit table for HRP2JSKNTS because we remove kawasakisan ankle parts.(https://github.com/start-jsk/rtmros_hrp2/pull/364)

### DIFF
--- a/hrpsys_ros_bridge_tutorials/euslisp/make-joint-min-max-table.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/make-joint-min-max-table.l
@@ -49,7 +49,7 @@
             :margin margin))
   ;; Hand made ankle-r ankle-p min-max table measured by real robot encoder values.
   ;;  This is for kawasaki-san ankle spacer.
-  (when (or (string= (send robot :name) "HRP2JSK") (string= (send robot :name) "HRP2JSKNT") (string= (send robot :name) "HRP2JSKNTS"))
+  (when (or (string= (send robot :name) "HRP2JSK") (string= (send robot :name) "HRP2JSKNT"))
     ;; set org-min-angle and org-max-angle for debug
     (send (send robot :joint "RLEG_JOINT5") :put :org-min-angle -29.0)
     (send (send robot :joint "RLEG_JOINT5") :put :org-max-angle 45.0)


### PR DESCRIPTION
Do not gen limit table for HRP2JSKNTS because we remove kawasakisan ankle parts.(https://github.com/start-jsk/rtmros_hrp2/pull/364)