### PR TITLE
[hrpsys_ros_bridge_tutorials] fix CMakeLists.txt

### DIFF
--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -377,7 +377,7 @@ endif()
 compile_rbrain_model_for_closed_robots(CHIDORI CHIDORI CHIDORI
   --robothardware-conf-file-option "pdgains.file_name: ${PROJECT_SOURCE_DIR}/models/PDgains.sav"
   ## do not use CHIDORI.conf for real robot
-  --conf-file-option "pdgains.file_name: ${PROJECT_SOURCE_DIR}/models/CHIDORI_PDgains.sav"
+  --conf-file-option "pdgains.file_name: ${PROJECT_SOURCE_DIR}/models/CHIDORI.PDgains.sav"
   --conf-file-option "pdgains_sim_file_name: ${PROJECT_SOURCE_DIR}/models/CHIDORI.PDgains_sim.dat"
   --conf-file-option "abc_leg_offset: 0.0, 0.1, 0.0"
   --conf-file-option "end_effectors: rleg,RLEG_JOINT5,WAIST,0.0,0.0,-0.110,0.0,0.0,0.0,0.0, lleg,LLEG_JOINT5,WAIST,0.0,0.0,-0.110,0.0,0.0,0.0,0.0,"


### PR DESCRIPTION
chidoriをchoreonoid上で動かしていた際に、gainの変更ができなかった(変更しようとすると0になる)ので、調べてみたところ、pdgains.file_nameが間違っていたようです。