### PR TITLE
[JAXON] fix default_zmp_offset for JAXON

### DIFF
--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/urata_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/urata_hrpsys_config.py
@@ -158,7 +158,7 @@ class URATAHrpsysConfigurator(HrpsysConfigurator):
         #abcp.default_zmp_offsets=[[0.015, 0.0, 0.0], [0.015, 0.0, 0.0], [0, 0, 0], [0, 0, 0]];
         abcp.default_zmp_offsets=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0, 0, 0], [0, 0, 0]];
         if self.ROBOT_NAME == "JAXON":
-            abcp.default_zmp_offsets=[[-0.02, 0.0, 0.0], [-0.02, 0.0, 0.0], [0, 0, 0], [0, 0, 0]];
+            abcp.default_zmp_offsets=[[0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0, 0, 0], [0, 0, 0]];
         elif self.ROBOT_NAME == "JAXON_RED":
             abcp.default_zmp_offsets=[[0.0, 0.01, 0.0], [0.0, -0.01, 0.0], [0, 0, 0], [0, 0, 0]];
         abcp.move_base_gain=0.8


### PR DESCRIPTION
https://github.com/start-jsk/rtmros_hrp2/pull/448
上記のモデル変更で、default_zmp_offsetは設定しなくても、ほぼend-coordsにzmpが来るようになっています。