### PR TITLE
[hrpsys_ros_bridge_tutorials] fix for min-max table

### DIFF
--- a/hrpsys_ros_bridge_tutorials/euslisp/hrp4r-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/hrp4r-utils.l
@@ -5,6 +5,8 @@
    ()
    (prog1
        (send-super :init-ending)
+     (when (member :define-min-max-table (send self :methods))
+       (send self :define-min-max-table))
      ;; set force-sensor from .conf
      (labels ((data-string-split ;; this function will be replaced by https://github.com/euslisp/EusLisp/issues/16
                (str separator)

--- a/hrpsys_ros_bridge_tutorials/euslisp/jaxon-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/jaxon-utils.l
@@ -6,6 +6,8 @@
    (&rest args)
    (prog1
        (send-super* :init-ending args)
+     (when (member :define-min-max-table (send self :methods))
+       (send self :define-min-max-table))
      (send self :add-hoist-point-coords)
      (send self :add-shin-cushion-parts)
      (send self :add-shin-contact-coords)

--- a/hrpsys_ros_bridge_tutorials/euslisp/jaxon_red-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/jaxon_red-utils.l
@@ -6,6 +6,8 @@
    (&rest args)
    (prog1
        (send-super* :init-ending args)
+     (when (member :define-min-max-table (send self :methods))
+       (send self :define-min-max-table))
      (send self :add-hoist-point-coords)
      (send self :add-shin-cushion-parts)
      (send self :add-shin-contact-coords)

--- a/hrpsys_ros_bridge_tutorials/euslisp/staro-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/staro-utils.l
@@ -66,6 +66,8 @@
    (&rest args)
    (prog1
     (send-super* :init-ending args)
+    (when (member :define-min-max-table (send self :methods))
+      (send self :define-min-max-table))
     (send self :add-additional-body-parts)
     
     ;; add contact-end-coords to arms


### PR DESCRIPTION
some robots ignore min-max table by overwriting :init-ending method in -utils.l