### PR TITLE
Fix initending and  mmtable

### DIFF
--- a/hrpsys_ros_bridge_tutorials/euslisp/hrp2g-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/hrp2g-utils.l
@@ -1,3 +1,11 @@
+(defmethod hrp2g-robot
+  (:init-ending
+   ()
+   (prog1
+       (send-super :init-ending)
+     (send self :define-min-max-table)
+     )))
+
 ;; stop and start grasp
 (defun hrp2g-stop-grasp (limb)
   (when (boundp '*hrp2g*)

--- a/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsk-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsk-utils.l
@@ -1,0 +1,7 @@
+(defmethod hrp2jsk-robot
+  (:init-ending
+   ()
+   (prog1
+       (send-super :init-ending)
+     (send self :define-min-max-table)
+     )))

--- a/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsknt-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsknt-utils.l
@@ -9,9 +9,9 @@
 
 (defmethod hrp2jsknt-robot
   (:init-ending
-   (&rest args)
+   ()
    (prog1
-       (send-super* :init-ending args)
+       (send-super :init-ending)
      (send self :set-additional-end-coords)
      (send self :define-min-max-table)
      ))

--- a/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsknts-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsknts-utils.l
@@ -8,6 +8,12 @@
     ,@(get-hrp2-with-hand-class-methods)))
 
 (defmethod hrp2jsknts-robot
+  (:init-ending
+   ()
+   (prog1
+       (send-super :init-ending)
+     (send self :define-min-max-table)
+     ))
   (:inverse-kinematics
    (target-coords
     &rest args

--- a/hrpsys_ros_bridge_tutorials/euslisp/hrp2w-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/hrp2w-utils.l
@@ -1,3 +1,11 @@
+(defmethod hrp2w-robot
+  (:init-ending
+   ()
+   (prog1
+       (send-super :init-ending)
+     (send self :define-min-max-table)
+     )))
+
 ;; stop and start grasp
 (defun hrp2w-stop-grasp (limb)
   (when (boundp '*hrp2w*)

--- a/hrpsys_ros_bridge_tutorials/euslisp/jaxon-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/jaxon-utils.l
@@ -14,6 +14,7 @@
      (send self :add-hip-contact-coords)
      (send self :put :lhand-model (instance dummy-thk-hand-robot :init :name :l-thk-hand))
      (send self :put :rhand-model (instance dummy-thk-hand-robot :init :name :r-thk-hand))
+     (send self :define-min-max-table)
      ))
   (:add-hoist-point-coords
    ()

--- a/hrpsys_ros_bridge_tutorials/euslisp/jaxon-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/jaxon-utils.l
@@ -3,9 +3,9 @@
 
 (defmethod JAXON-robot
   (:init-ending
-   (&rest args)
+   ()
    (prog1
-       (send-super* :init-ending args)
+       (send-super :init-ending)
      (send self :add-hoist-point-coords)
      (send self :add-shin-cushion-parts)
      (send self :add-shin-contact-coords)

--- a/hrpsys_ros_bridge_tutorials/euslisp/jaxon_red-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/jaxon_red-utils.l
@@ -14,6 +14,7 @@
      (send self :add-hip-contact-coords)
      (send self :put :lhand-model (instance dummy-thk-hand-robot :init :name :l-thk-hand))
      (send self :put :rhand-model (instance dummy-thk-hand-robot :init :name :r-thk-hand))
+     (send self :define-min-max-table)
      ))
   (:add-hoist-point-coords
    ()

--- a/hrpsys_ros_bridge_tutorials/euslisp/jaxon_red-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/jaxon_red-utils.l
@@ -3,9 +3,9 @@
 
 (defmethod JAXON_RED-robot
   (:init-ending
-   (&rest args)
+   ()
    (prog1
-       (send-super* :init-ending args)
+       (send-super :init-ending)
      (send self :add-hoist-point-coords)
      (send self :add-shin-cushion-parts)
      (send self :add-shin-contact-coords)

--- a/hrpsys_ros_bridge_tutorials/euslisp/make-joint-min-max-table.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/make-joint-min-max-table.l
@@ -161,14 +161,9 @@
   (with-open-file
    (f path :direction :output :if-exists :append)
    (format f "(defmethod ~A~%" (send (class robot) :name))
-   (format f "  (:init-ending~%")
-   (format f "    ()~%")
-   (format f "    (prog1~%")
-   (format f "      (send-super :init-ending)~%")
-   (format f "     (send self :define-min-max-table)~%")
-   (format f "    ))~%")
    (format f "  (:define-min-max-table~%")
    (format f "    ()~%")
+   (format f "    \"This method should be called in :init-ending.\"~%")
    (labels
        ((gen-string-name
          (j)

--- a/hrpsys_ros_bridge_tutorials/euslisp/staro-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/staro-utils.l
@@ -63,9 +63,9 @@
 
 (defmethod STARO-robot
   (:init-ending
-   (&rest args)
+   ()
    (prog1
-    (send-super* :init-ending args)
+    (send-super :init-ending)
     (send self :add-additional-body-parts)
     (send self :define-min-max-table)
     

--- a/hrpsys_ros_bridge_tutorials/euslisp/staro-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/staro-utils.l
@@ -67,6 +67,7 @@
    (prog1
     (send-super* :init-ending args)
     (send self :add-additional-body-parts)
+    (send self :define-min-max-table)
     
     ;; add contact-end-coords to arms
     (let (rarm-contact-end-coords larm-contact-end-coords)

--- a/hrpsys_ros_bridge_tutorials/test/test-all-robots-check.l
+++ b/hrpsys_ros_bridge_tutorials/test/test-all-robots-check.l
@@ -1,0 +1,25 @@
+#!/usr/bin/env roseus
+
+(require :unittest "lib/llib/unittest.l")
+(init-unit-test)
+
+(setq *all-robots* '(hrp2jsk hrp2jsknt hrp2jsknts hrp2w hrp2g urataleg jaxon jaxon_red chidori ystleg hrp4r staro))
+
+(deftest test-model-gen
+  (dolist (rb *all-robots*)
+    (load (format nil "package://hrpsys_ros_bridge_tutorials/euslisp/~A-interface.l" rb))
+    (format t ";; ~A done~%" (send (funcall rb) :name))
+    )
+  (assert t))
+
+(deftest test-joint-min-max-check
+  (dolist (rb *all-robots*)
+    (let ((check0 (not (not (find-method (eval (read-from-string (format nil "*~A*" rb))) :define-min-max-table))))
+          (check1 (not (not (find-if #'(lambda (j) (send j :joint-min-max-table)) (send (eval (read-from-string (format nil "*~A*" rb))) :joint-list))))))
+      (format t ";; ~10,A (has :define-min-max-table = ~3,A) (has min/max table = ~3,A) (total = ~3,A)~%"
+              rb check0 check1 (eq check0 check1))
+      (assert (eq check0 check1))
+      )))
+
+(run-all-tests)
+(exit)


### PR DESCRIPTION
Update version of #508.

修正点
- robot.l (hrp2jsk.lなど)の:init-endingをなくして、:init-endingは常にutils.lにあるようにする。min/max tableもutils.lの:init-endingで作る
- `&rest args`が元々:init-endingの要所要所についてましたが、不要だったのと、jskeusの:init-endingの引数仕様をかえてしまってることになるので、削除しました。
- checkコードをつけてみました
