### PR TITLE
Add offset from model to root link for euscollada/collada2eus_urdfmodel

### DIFF
--- a/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsk-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsk-utils.l
@@ -1,0 +1,17 @@
+(defmethod hrp2jsk-robot
+  (:init-ending
+   (&rest args)
+   (prog1
+       (send-super* :init-ending args)
+     (send self :define-min-max-table)
+     (when (< (norm (send (send (send self :worldcoords) :transformation
+                                (send (car (send self :links)) :worldcoords)) :pos))
+              0.1)
+       ;; for new collada version
+       (send self :dissoc (car (send self :links)))
+       (send self :translate (float-vector 0 0 -705)) ;; translation distance should be changed depend on WAIST Joint translation in .wrl
+       (send self :assoc (car (send self :links)))
+       (send self :reset-coords)
+       )
+     ))
+  )

--- a/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsknt-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsknt-utils.l
@@ -14,6 +14,15 @@
        (send-super* :init-ending args)
      (send self :set-additional-end-coords)
      (send self :define-min-max-table)
+     (when (< (norm (send (send (send self :worldcoords) :transformation
+                                (send (car (send self :links)) :worldcoords)) :pos))
+              0.1)
+       ;; for new collada version
+       (send self :dissoc (car (send self :links)))
+       (send self :translate (float-vector 0 0 -705)) ;; translation distance should be changed depend on WAIST Joint translation in .wrl
+       (send self :assoc (car (send self :links)))
+       (send self :reset-coords)
+       )
      ))
   (:inverse-kinematics
    (target-coords

--- a/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsknts-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/hrp2jsknts-utils.l
@@ -8,6 +8,21 @@
     ,@(get-hrp2-with-hand-class-methods)))
 
 (defmethod hrp2jsknts-robot
+  (:init-ending
+   (&rest args)
+   (prog1
+       (send-super* :init-ending args)
+     (send self :define-min-max-table)
+     (when (< (norm (send (send (send self :worldcoords) :transformation
+                                (send (car (send self :links)) :worldcoords)) :pos))
+              0.1)
+       ;; for new collada version
+       (send self :dissoc (car (send self :links)))
+       (send self :translate (float-vector 0 0 -708)) ;; translation distance should be changed depend on WAIST Joint translation in .wrl
+       (send self :assoc (car (send self :links)))
+       (send self :reset-coords)
+       )
+     ))
   (:inverse-kinematics
    (target-coords
     &rest args

--- a/hrpsys_ros_bridge_tutorials/euslisp/hrp4r-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/hrp4r-utils.l
@@ -7,6 +7,15 @@
        (send-super :init-ending)
      (when (member :define-min-max-table (send self :methods))
        (send self :define-min-max-table))
+     (when (< (norm (send (send (send self :worldcoords) :transformation
+                                (send (car (send self :links)) :worldcoords)) :pos))
+              0.1)
+       ;; for new collada version
+       (send self :dissoc (car (send self :links)))
+       (send self :translate (float-vector 0 0 -791)) ;; translation distance should be changed depend on WAIST Joint translation in .wrl
+       (send self :assoc (car (send self :links)))
+       (send self :reset-coords)
+       )
      ;; set force-sensor from .conf
      (labels ((data-string-split ;; this function will be replaced by https://github.com/euslisp/EusLisp/issues/16
                (str separator)

--- a/hrpsys_ros_bridge_tutorials/euslisp/jaxon-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/jaxon-utils.l
@@ -16,6 +16,15 @@
      (send self :add-hip-contact-coords)
      (send self :put :lhand-model (instance dummy-thk-hand-robot :init :name :l-thk-hand))
      (send self :put :rhand-model (instance dummy-thk-hand-robot :init :name :r-thk-hand))
+     (when (< (norm (send (send (send self :worldcoords) :transformation
+                                (send (car (send self :links)) :worldcoords)) :pos))
+              0.1)
+       ;; for new collada version
+       (send self :dissoc (car (send self :links)))
+       (send self :translate (float-vector 0 0 -1032.5)) ;; translation distance should be changed depend on WAIST Joint translation in .wrl
+       (send self :assoc (car (send self :links)))
+       (send self :reset-coords)
+       )
      ))
   (:add-hoist-point-coords
    ()

--- a/hrpsys_ros_bridge_tutorials/euslisp/jaxon_blue-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/jaxon_blue-utils.l
@@ -16,6 +16,15 @@
      (send self :add-hip-contact-coords)
      (send self :put :lhand-model (instance dummy-thk-hand-robot :init :name :l-thk-hand))
      (send self :put :rhand-model (instance dummy-thk-hand-robot :init :name :r-thk-hand))
+     (when (< (norm (send (send (send self :worldcoords) :transformation
+                                (send (car (send self :links)) :worldcoords)) :pos))
+              0.1)
+       ;; for new collada version
+       (send self :dissoc (car (send self :links)))
+       (send self :translate (float-vector 0 0 -1023.5)) ;; translation distance should be changed depend on WAIST Joint translation in .wrl
+       (send self :assoc (car (send self :links)))
+       (send self :reset-coords)
+       )
      ))
   (:add-hoist-point-coords
    ()

--- a/hrpsys_ros_bridge_tutorials/euslisp/jaxon_red-utils.l
+++ b/hrpsys_ros_bridge_tutorials/euslisp/jaxon_red-utils.l
@@ -16,6 +16,15 @@
      (send self :add-hip-contact-coords)
      (send self :put :lhand-model (instance dummy-thk-hand-robot :init :name :l-thk-hand))
      (send self :put :rhand-model (instance dummy-thk-hand-robot :init :name :r-thk-hand))
+     (when (< (norm (send (send (send self :worldcoords) :transformation
+                                (send (car (send self :links)) :worldcoords)) :pos))
+              0.1)
+       ;; for new collada version
+       (send self :dissoc (car (send self :links)))
+       (send self :translate (float-vector 0 0 -1018.5)) ;; translation distance should be changed depend on WAIST Joint translation in .wrl
+       (send self :assoc (car (send self :links)))
+       (send self :reset-coords)
+       )
      ))
   (:add-hoist-point-coords
    ()


### PR DESCRIPTION
For backward compatibility, new collada2eus does not translate root link.
This information (robot model to root link) is not in urdf model.