### PR TITLE
Separate urata_hrpsys_config.py to each robot config

### DIFF
--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/chidori_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/chidori_hrpsys_config.py
@@ -3,6 +3,11 @@
 from urata_hrpsys_config import *
 
 class CHIDORIHrpsysConfigurator(URATAHrpsysConfigurator):
+    """
+    Subclass for CHIDORI configuration.
+    Please inherit this class to specify environmnet-dependent class.
+    """
+
     def __init__(self):
         URATAHrpsysConfigurator.__init__(self, "CHIDORI")
 

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/jaxon_blue_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/jaxon_blue_hrpsys_config.py
@@ -3,6 +3,11 @@
 from urata_hrpsys_config import *
 
 class JAXON_BLUEHrpsysConfigurator(URATAHrpsysConfigurator):
+    """
+    Subclass for JAXON_BLUE configuration.
+    Please inherit this class to specify environmnet-dependent class.
+    """
+
     def __init__(self):
         URATAHrpsysConfigurator.__init__(self, "JAXON_BLUE")
 

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/jaxon_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/jaxon_hrpsys_config.py
@@ -3,6 +3,14 @@
 from urata_hrpsys_config import *
 
 class JAXONHrpsysConfigurator(URATAHrpsysConfigurator):
+    """
+    Subclass for JAXON configuration.
+    This class has JAXON-dependent code and
+    common functions for JAXON and JAXON_RED.
+    Please inherit this class to specify JAXON_RED or
+    environmnet-dependent class.
+    """
+
     def __init__(self):
         URATAHrpsysConfigurator.__init__(self, "JAXON")
 

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/jaxon_red_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/jaxon_red_hrpsys_config.py
@@ -3,6 +3,12 @@
 from jaxon_hrpsys_config import *
 
 class JAXON_REDHrpsysConfigurator(JAXONHrpsysConfigurator):
+    """
+    Subclass for JAXON_RED configuration.
+    This class overrides some functions for JAXON_RED.
+    Please inherit this class to specify environmnet-dependent class.
+    """
+
     def __init__(self):
         URATAHrpsysConfigurator.__init__(self, "JAXON_RED")
 

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/staro_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/staro_hrpsys_config.py
@@ -3,6 +3,11 @@
 from urata_hrpsys_config import *
 
 class STAROHrpsysConfigurator(URATAHrpsysConfigurator):
+    """
+    Subclass for STARO configuration.
+    Please inherit this class to specify environmnet-dependent class.
+    """
+
     def __init__(self):
         URATAHrpsysConfigurator.__init__(self, "STARO")
 

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/tqleg0_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/tqleg0_hrpsys_config.py
@@ -3,6 +3,11 @@
 from urata_hrpsys_config import *
 
 class TQLEG0HrpsysConfigurator(URATAHrpsysConfigurator):
+    """
+    Subclass for TQLEG0 configuration.
+    Please inherit this class to specify environmnet-dependent class.
+    """
+
     def __init__(self):
         URATAHrpsysConfigurator.__init__(self, "TQLEG0")
 

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/urata_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/urata_hrpsys_config.py
@@ -9,6 +9,11 @@ import OpenHRP
 import math
 
 class URATAHrpsysConfigurator(HrpsysConfigurator):
+    """
+    Abstract class for JSK robot configuration.
+    Please inherit this class to specify robot or environmnet-dependent class.
+    """
+
     def __init__(self, robotname=""):
         self.ROBOT_NAME = robotname
         HrpsysConfigurator.__init__(self)

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/urataleg_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/urataleg_hrpsys_config.py
@@ -3,6 +3,11 @@
 from urata_hrpsys_config import *
 
 class URATALEGHrpsysConfigurator(URATAHrpsysConfigurator):
+    """
+    Subclass for URATALEG configuration.
+    Please inherit this class to specify environmnet-dependent class.
+    """
+
     def __init__(self):
         URATAHrpsysConfigurator.__init__(self, "URATALEG")
 

--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/ystleg_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/ystleg_hrpsys_config.py
@@ -3,6 +3,11 @@
 from urata_hrpsys_config import *
 
 class YSTLEGHrpsysConfigurator(URATAHrpsysConfigurator):
+    """
+    Subclass for YSTLEG configuration.
+    Please inherit this class to specify environmnet-dependent class.
+    """
+
     def __init__(self):
         URATAHrpsysConfigurator.__init__(self, "YSTLEG")
 


### PR DESCRIPTION
Ref: #557 
Please do not merge yet.
urata_hrpsys_config.pyに書かれていた主な設定を各ロボットのsetup.pyに分離しました．
方針としてこれで良いのか，レビューお願いします．

Choreonoid，実機の設定を確認したのちにマージをお願いします．
各ロボットを使用する方は移行漏れがないか確認おねがいします．
また，ローカルdiffがある方はマージの時にコンフリクトが出るはずなので気をつけてください．