### PR TITLE
[hrpsys_ros_bridge_tutorials/launch] fix hironx model path

### DIFF
--- a/hrpsys_ros_bridge_tutorials/launch/hironx_ros_bridge.launch
+++ b/hrpsys_ros_bridge_tutorials/launch/hironx_ros_bridge.launch
@@ -5,8 +5,8 @@
 
   <include file="$(find hrpsys_ros_bridge)/launch/hrpsys_ros_bridge.launch">
     <arg name="SIMULATOR_NAME" value="HiroNX(Robot)0" />
-    <arg name="MODEL_FILE" value="$(find collada_robots)/data/robots/kawada-hironx.dae" />
-    <arg name="COLLADA_FILE" value="$(find collada_robots)/data/robots/kawada-hironx.dae" />
+    <arg name="MODEL_FILE" value="$(find hironx_ros_bridge)/models/kawada-hironx.dae" />
+    <arg name="COLLADA_FILE" value="$(find hironx_ros_bridge)/models/kawada-hironx.dae" />
   </include>
 
   <node name="hironx_rviz" pkg="rviz" type="rviz" respawn="true"

--- a/hrpsys_ros_bridge_tutorials/launch/hironx_startup.launch
+++ b/hrpsys_ros_bridge_tutorials/launch/hironx_startup.launch
@@ -7,9 +7,9 @@
   <param name="use_sim_time" value="true" />
   <!-- end use sim time -->
   <include file="$(find hrpsys_tools)/launch/hrpsys.launch">
-    <arg name="PROJECT_FILE" value="$(find hrpsys_ros_bridge_tutorials)/models/kawada-hironx_nosim.xml" if="$(arg NOSIM)"/>
-    <arg name="PROJECT_FILE" value="$(find hrpsys_ros_bridge_tutorials)/models/kawada-hironx.xml" unless="$(arg NOSIM)"/>
-    <arg name="MODEL_FILE" value="$(find collada_robots)/data/robots/kawada-hironx.dae" />
+    <arg name="PROJECT_FILE" value="$(find hironx_ros_bridge)/conf/kawada-hironx_nosim.xml" if="$(arg NOSIM)"/>
+    <arg name="PROJECT_FILE" value="$(find hironx_ros_bridge)/conf/kawada-hironx.xml" unless="$(arg NOSIM)"/>
+    <arg name="MODEL_FILE" value="$(find hironx_ros_bridge)/models/kawada-hironx.dae" />
     <arg name="CONF_FILE" value="$(find hrpsys_ros_bridge_tutorials)/models/kawada-hironx.conf" />
     <arg name="SIMULATOR_NAME" value="HiroNX(Robot)0" />
     <arg name="KILL_SERVERS" default="$(arg KILL_SERVERS)" />


### PR DESCRIPTION
ご無沙汰しております。
ロボットモデルの管理について、認識が誤っているかもしれないので、内容をご確認ください。

ros kinetic環境で、hrpsys_ros_bridge_tutorials, hironx_ros_bridgeをビルドしたところ、
hironxのモデルのパスがずれていたので修正しました。

1. collada_robotsパッケージはopenrave_planningの中にあり、
hironxを使用する上で必ずしも必要ないと思うので、
hironx_ros_bridgeのモデルを読むようにしました。

2. また、私の環境では、hrpsys_ros_bridge_tutorials/models以下に
kawada-hironx.xml等が生成されることはなかったので、
hironx_ros_bridgeに読みに行くよう修正したのですが、
hrpsys_ros_bridge_tutorials/modelsに同xmlが生成される方が正しい挙動でしょうか？

どうぞよろしくお願いいたします。
