### PR TITLE
fix .travis.rosinstall.kinetic (use rtm-ros-robotics directory)

### DIFF
--- a/.travis.rosinstall.kinetic
+++ b/.travis.rosinstall.kinetic
@@ -1,4 +1,4 @@
 # Dependencies of hrpsys_gazebo_tutorials, but not released in kinetic
 - git:
-    local-name: rtmros_gazebo
+    local-name: rtm-ros-robotics/rtmros_gazebo
     uri: https://github.com/start-jsk/rtmros_gazebo.git


### PR DESCRIPTION
https://github.com/start-jsk/rtmros_tutorials/pull/566

* fix .travis.rosinstall.kinetic to put `rtmros_gazebo` under the `rtm-ros-robotics` directory
