### PR TITLE
[on #250 of start-jsk/rtmros_gazebo][hrpsys_gazebo_tutorials] enable samplerobot and hrp2 on kinetic and melodic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ roseus samplerobot-interface.l
 Open Terminal and run gazebo
 
 ```
-roslaunch hrpsys_gazebo_tutorials gazebo_hrp2jsknt_no_controllers.launch
+roslaunch hrpsys_gazebo_tutorials gazebo_hrp2jsknt_no_controllers.launch #kinetic or melodic
+roslaunch hrpsys_gazebo_tutorials gazebo_hrp2jsknt_no_controllers_indigo.launch #indigo
 ```
 Launch another terminal and start hrpsys-base
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Open Terminal and run gazebo
 
 ```
 roslaunch hrpsys_gazebo_tutorials gazebo_samplerobot_no_controllers.launch #kinetic or melodic
-roslaunch hrpsys_gazebo_tutorials gazebo_hrp2jsknt_no_controllers_indigo.launch #indigo
+roslaunch hrpsys_gazebo_tutorials gazebo_samplerobot_no_controllers_indigo.launch #indigo
 ```
 Launch another terminal and start hrpsys-base
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ If you use closed models, you have to compile `hrpsys_ros_bridge_tutorials` afte
 Open Terminal and run gazebo
 
 ```
-roslaunch hrpsys_gazebo_tutorials gazebo_samplerobot_no_controllers.launch
+roslaunch hrpsys_gazebo_tutorials gazebo_samplerobot_no_controllers.launch #kinetic or melodic
+roslaunch hrpsys_gazebo_tutorials gazebo_hrp2jsknt_no_controllers_indigo.launch #indigo
 ```
 Launch another terminal and start hrpsys-base
 ```

--- a/hrpsys_gazebo_tutorials/config/HRP2JSK.yaml
+++ b/hrpsys_gazebo_tutorials/config/HRP2JSK.yaml
@@ -1,6 +1,6 @@
 hrpsys_gazebo_configuration:
 ### velocity feedback for joint control, use parameter gains/joint_name/p_v
-  use_velocity_feedback: true
+  use_velocity_feedback: false
   use_joint_effort: true
   iob_rate: 250
 ### loose synchronization default true
@@ -47,38 +47,38 @@ hrpsys_gazebo_configuration:
     - LARM_JOINT6
     - LARM_JOINT7
   gains:
-    CHEST_JOINT0: {p: 3000.0, d:   8.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    CHEST_JOINT1: {p: 1000.0, d:   4.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    HEAD_JOINT0:  {p:  150.0, d:   0.5, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    HEAD_JOINT1:  {p:  700.0, d:   1.5, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    LARM_JOINT0:  {p: 2000.0, d:   4.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    LARM_JOINT1:  {p: 1000.0, d:   2.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    LARM_JOINT2:  {p:  200.0, d:   0.4, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    LARM_JOINT3:  {p: 1500.0, d:   3.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    LARM_JOINT4:  {p:  200.0, d:   0.4, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    LARM_JOINT5:  {p:  400.0, d:   0.8, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    LARM_JOINT6:  {p:  400.0, d:   0.8, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    LARM_JOINT7:  {p:   20.0, d:  0.02, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RARM_JOINT0:  {p: 2000.0, d:   4.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RARM_JOINT1:  {p: 1000.0, d:   2.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RARM_JOINT2:  {p:  200.0, d:   0.4, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RARM_JOINT3:  {p: 1500.0, d:   3.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RARM_JOINT4:  {p:  200.0, d:   0.4, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RARM_JOINT5:  {p:  400.0, d:   0.8, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RARM_JOINT6:  {p:  400.0, d:   0.8, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RARM_JOINT7:  {p:   20.0, d:  0.02, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    LLEG_JOINT0:  {p: 1500.0, d:   2.0, i: 0.0, i_clamp: 0.0, p_v: 350.0} # CRTOCH-Y
-    LLEG_JOINT1:  {p: 2000.0, d:   4.0, i: 0.0, i_clamp: 0.0, vp: 4.0, p_v: 350.0} # CRTOCH-R
-    LLEG_JOINT2:  {p: 3800.0, d:  15.0, i: 0.0, i_clamp: 0.0, vp: 4.0, p_v: 350.0} # CRTOCH-P
-    LLEG_JOINT3:  {p: 3400.0, d:  12.5, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0} # KNEE-P
-    LLEG_JOINT4:  {p: 2800.0, d:  10.0, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0} # ANKLE-P
-    LLEG_JOINT5:  {p: 2000.0, d:   4.0, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0} # ANKLE-R
-    RLEG_JOINT0:  {p: 1500.0, d:   2.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RLEG_JOINT1:  {p: 2000.0, d:   4.0, i: 0.0, i_clamp: 0.0, vp: 4.0, p_v: 350.0}
-    RLEG_JOINT2:  {p: 3800.0, d:  15.0, i: 0.0, i_clamp: 0.0, vp: 4.0, p_v: 350.0}
-    RLEG_JOINT3:  {p: 3400.0, d:  12.5, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0}
-    RLEG_JOINT4:  {p: 2800.0, d:  10.0, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0}
-    RLEG_JOINT5:  {p: 2000.0, d:   2.0, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0}
+    CHEST_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    CHEST_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    HEAD_JOINT0:  {p: 400.0, d:   0.040, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    HEAD_JOINT1:  {p: 400.0, d:   0.040, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT0:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT1:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT2:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT3:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT4:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT5:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT6:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT7:  {p:  20.0, d:   0.020, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT0:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT1:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT2:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT3:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT4:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT5:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT6:  {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT7:  {p:  20.0, d:   0.020, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LLEG_JOINT0:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # CRTOCH-Y
+    LLEG_JOINT1:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, vp: 0.0, p_v: 350.0} # CRTOCH-R
+    LLEG_JOINT2:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, vp: 0.0, p_v: 350.0} # CRTOCH-P
+    LLEG_JOINT3:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, vp: 0.0, p_v: 350.0} # KNEE-P
+    LLEG_JOINT4:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, vp: 0.0, p_v: 350.0} # ANKLE-P
+    LLEG_JOINT5:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, vp: 0.0, p_v: 350.0} # ANKLE-R
+    RLEG_JOINT0:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT1:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, vp: 0.0, p_v: 350.0}
+    RLEG_JOINT2:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, vp: 0.0, p_v: 350.0}
+    RLEG_JOINT3:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, vp: 0.0, p_v: 350.0}
+    RLEG_JOINT4:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, vp: 0.0, p_v: 350.0}
+    RLEG_JOINT5:  {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, vp: 0.0, p_v: 350.0}
 
   force_torque_sensors:
     - rfsensor
@@ -94,5 +94,5 @@ hrpsys_gazebo_configuration:
   imu_sensors:
     - imu_sensor0
   imu_sensors_config:
-## TODO: add translation and rotation
+## pose of IMU sensor should be written in URDF
     imu_sensor0: {ros_name: 'waist_imu', link_name: 'CHEST_LINK1', frame_id: 'CHEST_LINK1'}

--- a/hrpsys_gazebo_tutorials/config/HRP2JSKNT.yaml
+++ b/hrpsys_gazebo_tutorials/config/HRP2JSKNT.yaml
@@ -1,6 +1,6 @@
 hrpsys_gazebo_configuration:
 ### velocity feedback for joint control, use parameter gains/joint_name/p_v
-  use_velocity_feedback: true
+  use_velocity_feedback: false
   use_joint_effort: true
   iob_rate: 250
 ### loose synchronization default true
@@ -80,20 +80,20 @@ hrpsys_gazebo_configuration:
     RARM_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
     RARM_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
     RARM_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
-    LLEG_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0} # CRTOCH-Y
-    LLEG_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # CRTOCH-R
-    LLEG_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0} # CRTOCH-P
-    LLEG_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0} # KNEE-P
-    LLEG_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-P
-    LLEG_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-R
-    LLEG_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0} # TOE-R
-    RLEG_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RLEG_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0}
-    RLEG_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0}
-    RLEG_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RLEG_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RLEG_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_JOINT0: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0} # CRTOCH-Y
+    LLEG_JOINT1: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # CRTOCH-R
+    LLEG_JOINT2: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0} # CRTOCH-P
+    LLEG_JOINT3: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0} # KNEE-P
+    LLEG_JOINT4: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-P
+    LLEG_JOINT5: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-R
+    LLEG_JOINT6: {p: 120.0, d:   0.013, i: 0.0, i_clamp: 0.0, p_v: 250.0} # TOE-R
+    RLEG_JOINT0: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_JOINT1: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT2: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0}
+    RLEG_JOINT3: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0}
+    RLEG_JOINT4: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT5: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT6: {p: 120.0, d:   0.013, i: 0.0, i_clamp: 0.0, p_v: 250.0}
     L_INDEXMP_R:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
     L_INDEXMP_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
     L_INDEXPIP_R:  {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
@@ -121,5 +121,5 @@ hrpsys_gazebo_configuration:
   imu_sensors:
     - imu_sensor0
   imu_sensors_config:
-## TODO: add translation and rotation
+## pose of IMU sensor should be written in URDF
     imu_sensor0: {ros_name: 'waist_imu', link_name: 'CHEST_LINK1', frame_id: 'CHEST_LINK1'}

--- a/hrpsys_gazebo_tutorials/config/HRP2JSKNTS.yaml
+++ b/hrpsys_gazebo_tutorials/config/HRP2JSKNTS.yaml
@@ -1,6 +1,6 @@
 hrpsys_gazebo_configuration:
 ### velocity feedback for joint control, use parameter gains/joint_name/p_v
-  use_velocity_feedback: true
+  use_velocity_feedback: false
   use_joint_effort: true
   iob_rate: 250
 ### loose synchronization default true
@@ -79,21 +79,21 @@ hrpsys_gazebo_configuration:
     RARM_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
     RARM_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
     RARM_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
-    RARM_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
-    LLEG_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0} # CRTOCH-Y
-    LLEG_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # CRTOCH-R
-    LLEG_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0} # CRTOCH-P
-    LLEG_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0} # KNEE-P
-    LLEG_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-P
-    LLEG_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-R
+    RARM_JOINT6: {p: 120.0, d:   0.013, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LLEG_JOINT0: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0} # CRTOCH-Y
+    LLEG_JOINT1: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # CRTOCH-R
+    LLEG_JOINT2: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0} # CRTOCH-P
+    LLEG_JOINT3: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0} # KNEE-P
+    LLEG_JOINT4: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-P
+    LLEG_JOINT5: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-R
     LLEG_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0} # TOE-R
-    RLEG_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RLEG_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0}
-    RLEG_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0}
-    RLEG_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RLEG_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
-    RLEG_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_JOINT0: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_JOINT1: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT2: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0}
+    RLEG_JOINT3: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0}
+    RLEG_JOINT4: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT5: {p: 1000.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT6: {p: 120.0, d:   0.013, i: 0.0, i_clamp: 0.0, p_v: 250.0}
     L_INDEXMP_R:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
     L_INDEXMP_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
     L_INDEXPIP_R:  {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
@@ -121,5 +121,5 @@ hrpsys_gazebo_configuration:
   imu_sensors:
     - imu_sensor0
   imu_sensors_config:
-## TODO: add translation and rotation
+## pose of IMU sensor should be written in URDF
     imu_sensor0: {ros_name: 'waist_imu', link_name: 'CHEST_LINK1', frame_id: 'CHEST_LINK1'}

--- a/hrpsys_gazebo_tutorials/config/HRP2JSKNTS_indigo.yaml
+++ b/hrpsys_gazebo_tutorials/config/HRP2JSKNTS_indigo.yaml
@@ -1,0 +1,125 @@
+hrpsys_gazebo_configuration:
+### velocity feedback for joint control, use parameter gains/joint_name/p_v
+  use_velocity_feedback: true
+  use_joint_effort: true
+  iob_rate: 250
+### loose synchronization default true
+# use_loose_synchronized: false
+### synchronized hrpsys and gazebo
+# use_synchronized_command: false
+# iob_substeps: 5
+### name of robot (using for namespace)
+  robotname: HRP2JSKNTS
+### joint_id (order) conversion from gazebo to hrpsys, joint_id_list[gazebo_id] := hrpsys_id
+  joint_id_list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45]
+### joints : list used in gazebo, sizeof(joint_id_list) == sizeof(joints)
+  joints:
+    - RLEG_JOINT0
+    - RLEG_JOINT1
+    - RLEG_JOINT2
+    - RLEG_JOINT3
+    - RLEG_JOINT4
+    - RLEG_JOINT5
+    - RLEG_JOINT6
+    - LLEG_JOINT0
+    - LLEG_JOINT1
+    - LLEG_JOINT2
+    - LLEG_JOINT3
+    - LLEG_JOINT4
+    - LLEG_JOINT5
+    - LLEG_JOINT6
+    - CHEST_JOINT0
+    - CHEST_JOINT1
+    - HEAD_JOINT0
+    - HEAD_JOINT1
+    - RARM_JOINT0
+    - RARM_JOINT1
+    - RARM_JOINT2
+    - RARM_JOINT3
+    - RARM_JOINT4
+    - RARM_JOINT5
+    - RARM_JOINT6
+    - RARM_JOINT7
+    - LARM_JOINT0
+    - LARM_JOINT1
+    - LARM_JOINT2
+    - LARM_JOINT3
+    - LARM_JOINT4
+    - LARM_JOINT5
+    - LARM_JOINT6
+    - LARM_JOINT7
+    - L_THUMBCM_Y
+    - L_THUMBCM_P
+    - L_INDEXMP_R
+    - L_INDEXMP_P
+    - L_INDEXPIP_R
+    - L_MIDDLEPIP_R
+    - R_THUMBCM_Y
+    - R_THUMBCM_P
+    - R_INDEXMP_R
+    - R_INDEXMP_P
+    - R_INDEXPIP_R
+    - R_MIDDLEPIP_R
+## jointid:
+  gains:
+    CHEST_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    CHEST_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    HEAD_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    HEAD_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LLEG_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0} # CRTOCH-Y
+    LLEG_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # CRTOCH-R
+    LLEG_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0} # CRTOCH-P
+    LLEG_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0} # KNEE-P
+    LLEG_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-P
+    LLEG_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-R
+    LLEG_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0} # TOE-R
+    RLEG_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0}
+    RLEG_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0}
+    RLEG_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    L_INDEXMP_R:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_INDEXMP_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_INDEXPIP_R:  {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_MIDDLEPIP_R: {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_THUMBCM_Y:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_THUMBCM_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXMP_R:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXMP_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXPIP_R:  {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_MIDDLEPIP_R: {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_THUMBCM_Y:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_THUMBCM_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+
+  force_torque_sensors:
+    - rfsensor
+    - lfsensor
+    - rhsensor
+    - lhsensor
+  force_torque_sensors_config:
+## TODO: add translation and rotation
+    lfsensor: {joint_name: 'LLEG_JOINT5', frame_id: 'LLEG_LINK5', translation: [0, 0, -0.105], rotation: [1, 0, 0, 0]}
+    rfsensor: {joint_name: 'RLEG_JOINT5', frame_id: 'RLEG_LINK5', translation: [0, 0, -0.105], rotation: [1, 0, 0, 0]}
+    lhsensor: {joint_name: 'LARM_JOINT6', frame_id: 'LARM_LINK6', translation: [0, 0, -0.0775], rotation: [1, 0, 0, 0]}
+    rhsensor: {joint_name: 'RARM_JOINT6', frame_id: 'RARM_LINK6', translation: [0, 0, -0.0775], rotation: [1, 0, 0, 0]}
+  imu_sensors:
+    - imu_sensor0
+  imu_sensors_config:
+## TODO: add translation and rotation
+    imu_sensor0: {ros_name: 'waist_imu', link_name: 'CHEST_LINK1', frame_id: 'CHEST_LINK1'}

--- a/hrpsys_gazebo_tutorials/config/HRP2JSKNT_indigo.yaml
+++ b/hrpsys_gazebo_tutorials/config/HRP2JSKNT_indigo.yaml
@@ -1,0 +1,125 @@
+hrpsys_gazebo_configuration:
+### velocity feedback for joint control, use parameter gains/joint_name/p_v
+  use_velocity_feedback: true
+  use_joint_effort: true
+  iob_rate: 250
+### loose synchronization default true
+# use_loose_synchronized: false
+### synchronized hrpsys and gazebo
+# use_synchronized_command: false
+# iob_substeps: 5
+### name of robot (using for namespace)
+  robotname: HRP2JSKNT
+### joint_id (order) conversion from gazebo to hrpsys, joint_id_list[gazebo_id] := hrpsys_id
+  joint_id_list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45]
+### joints : list used in gazebo, sizeof(joint_id_list) == sizeof(joints)
+  joints:
+    - RLEG_JOINT0
+    - RLEG_JOINT1
+    - RLEG_JOINT2
+    - RLEG_JOINT3
+    - RLEG_JOINT4
+    - RLEG_JOINT5
+    - RLEG_JOINT6
+    - LLEG_JOINT0
+    - LLEG_JOINT1
+    - LLEG_JOINT2
+    - LLEG_JOINT3
+    - LLEG_JOINT4
+    - LLEG_JOINT5
+    - LLEG_JOINT6
+    - CHEST_JOINT0
+    - CHEST_JOINT1
+    - HEAD_JOINT0
+    - HEAD_JOINT1
+    - RARM_JOINT0
+    - RARM_JOINT1
+    - RARM_JOINT2
+    - RARM_JOINT3
+    - RARM_JOINT4
+    - RARM_JOINT5
+    - RARM_JOINT6
+    - RARM_JOINT7
+    - LARM_JOINT0
+    - LARM_JOINT1
+    - LARM_JOINT2
+    - LARM_JOINT3
+    - LARM_JOINT4
+    - LARM_JOINT5
+    - LARM_JOINT6
+    - LARM_JOINT7
+    - L_THUMBCM_Y
+    - L_THUMBCM_P
+    - L_INDEXMP_R
+    - L_INDEXMP_P
+    - L_INDEXPIP_R
+    - L_MIDDLEPIP_R
+    - R_THUMBCM_Y
+    - R_THUMBCM_P
+    - R_INDEXMP_R
+    - R_INDEXMP_P
+    - R_INDEXPIP_R
+    - R_MIDDLEPIP_R
+## jointid:
+  gains:
+    CHEST_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    CHEST_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    HEAD_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    HEAD_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LARM_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    RARM_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 150.0}
+    LLEG_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0} # CRTOCH-Y
+    LLEG_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # CRTOCH-R
+    LLEG_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0} # CRTOCH-P
+    LLEG_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0} # KNEE-P
+    LLEG_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-P
+    LLEG_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0} # ANKLE-R
+    LLEG_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0} # TOE-R
+    RLEG_JOINT0: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_JOINT1: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT2: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 325.0}
+    RLEG_JOINT3: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 450.0}
+    RLEG_JOINT4: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT5: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT6: {p: 700.0, d:   0.075, i: 0.0, i_clamp: 0.0, p_v: 250.0}
+    L_INDEXMP_R:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_INDEXMP_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_INDEXPIP_R:  {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_MIDDLEPIP_R: {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_THUMBCM_Y:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    L_THUMBCM_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXMP_R:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXMP_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_INDEXPIP_R:  {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_MIDDLEPIP_R: {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_THUMBCM_Y:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+    R_THUMBCM_P:   {p: 10.0, d:   0.01, i: 0.0, i_clamp: 0.0, p_v: 10.0}
+
+  force_torque_sensors:
+    - rfsensor
+    - lfsensor
+    - rhsensor
+    - lhsensor
+  force_torque_sensors_config:
+## TODO: add translation and rotation
+    lfsensor: {joint_name: 'LLEG_JOINT5', frame_id: 'LLEG_LINK5', translation: [0, 0, -0.105], rotation: [1, 0, 0, 0]}
+    rfsensor: {joint_name: 'RLEG_JOINT5', frame_id: 'RLEG_LINK5', translation: [0, 0, -0.105], rotation: [1, 0, 0, 0]}
+    lhsensor: {joint_name: 'LARM_JOINT6', frame_id: 'LARM_LINK6', translation: [0, 0, -0.0775], rotation: [1, 0, 0, 0]}
+    rhsensor: {joint_name: 'RARM_JOINT6', frame_id: 'RARM_LINK6', translation: [0, 0, -0.0775], rotation: [1, 0, 0, 0]}
+  imu_sensors:
+    - imu_sensor0
+  imu_sensors_config:
+## TODO: add translation and rotation
+    imu_sensor0: {ros_name: 'waist_imu', link_name: 'CHEST_LINK1', frame_id: 'CHEST_LINK1'}

--- a/hrpsys_gazebo_tutorials/config/HRP2JSK_indigo.yaml
+++ b/hrpsys_gazebo_tutorials/config/HRP2JSK_indigo.yaml
@@ -1,0 +1,98 @@
+hrpsys_gazebo_configuration:
+### velocity feedback for joint control, use parameter gains/joint_name/p_v
+  use_velocity_feedback: true
+  use_joint_effort: true
+  iob_rate: 250
+### loose synchronization default true
+# use_loose_synchronized: false
+### synchronized hrpsys and gazebo
+# use_synchronized_command: false
+# iob_substeps: 5
+### name of robot (using for namespace)
+  robotname: HRP2JSK
+### joint_id (order) conversion from gazebo to hrpsys, joint_id_list[gazebo_id] := hrpsys_id
+  joint_id_list: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
+### joints : list used in gazebo, sizeof(joint_id_list) == sizeof(joints)
+  joints:
+    - RLEG_JOINT0
+    - RLEG_JOINT1
+    - RLEG_JOINT2
+    - RLEG_JOINT3
+    - RLEG_JOINT4
+    - RLEG_JOINT5
+    - LLEG_JOINT0
+    - LLEG_JOINT1
+    - LLEG_JOINT2
+    - LLEG_JOINT3
+    - LLEG_JOINT4
+    - LLEG_JOINT5
+    - CHEST_JOINT0
+    - CHEST_JOINT1
+    - HEAD_JOINT0
+    - HEAD_JOINT1
+    - RARM_JOINT0
+    - RARM_JOINT1
+    - RARM_JOINT2
+    - RARM_JOINT3
+    - RARM_JOINT4
+    - RARM_JOINT5
+    - RARM_JOINT6
+    - RARM_JOINT7
+    - LARM_JOINT0
+    - LARM_JOINT1
+    - LARM_JOINT2
+    - LARM_JOINT3
+    - LARM_JOINT4
+    - LARM_JOINT5
+    - LARM_JOINT6
+    - LARM_JOINT7
+  gains:
+    CHEST_JOINT0: {p: 3000.0, d:   8.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    CHEST_JOINT1: {p: 1000.0, d:   4.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    HEAD_JOINT0:  {p:  150.0, d:   0.5, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    HEAD_JOINT1:  {p:  700.0, d:   1.5, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT0:  {p: 2000.0, d:   4.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT1:  {p: 1000.0, d:   2.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT2:  {p:  200.0, d:   0.4, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT3:  {p: 1500.0, d:   3.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT4:  {p:  200.0, d:   0.4, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT5:  {p:  400.0, d:   0.8, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT6:  {p:  400.0, d:   0.8, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LARM_JOINT7:  {p:   20.0, d:  0.02, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT0:  {p: 2000.0, d:   4.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT1:  {p: 1000.0, d:   2.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT2:  {p:  200.0, d:   0.4, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT3:  {p: 1500.0, d:   3.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT4:  {p:  200.0, d:   0.4, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT5:  {p:  400.0, d:   0.8, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT6:  {p:  400.0, d:   0.8, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RARM_JOINT7:  {p:   20.0, d:  0.02, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    LLEG_JOINT0:  {p: 1500.0, d:   2.0, i: 0.0, i_clamp: 0.0, p_v: 350.0} # CRTOCH-Y
+    LLEG_JOINT1:  {p: 2000.0, d:   4.0, i: 0.0, i_clamp: 0.0, vp: 4.0, p_v: 350.0} # CRTOCH-R
+    LLEG_JOINT2:  {p: 3800.0, d:  15.0, i: 0.0, i_clamp: 0.0, vp: 4.0, p_v: 350.0} # CRTOCH-P
+    LLEG_JOINT3:  {p: 3400.0, d:  12.5, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0} # KNEE-P
+    LLEG_JOINT4:  {p: 2800.0, d:  10.0, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0} # ANKLE-P
+    LLEG_JOINT5:  {p: 2000.0, d:   4.0, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0} # ANKLE-R
+    RLEG_JOINT0:  {p: 1500.0, d:   2.0, i: 0.0, i_clamp: 0.0, p_v: 350.0}
+    RLEG_JOINT1:  {p: 2000.0, d:   4.0, i: 0.0, i_clamp: 0.0, vp: 4.0, p_v: 350.0}
+    RLEG_JOINT2:  {p: 3800.0, d:  15.0, i: 0.0, i_clamp: 0.0, vp: 4.0, p_v: 350.0}
+    RLEG_JOINT3:  {p: 3400.0, d:  12.5, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0}
+    RLEG_JOINT4:  {p: 2800.0, d:  10.0, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0}
+    RLEG_JOINT5:  {p: 2000.0, d:   2.0, i: 0.0, i_clamp: 0.0, vp: 2.0, p_v: 350.0}
+
+  force_torque_sensors:
+    - rfsensor
+    - lfsensor
+    - rhsensor
+    - lhsensor
+  force_torque_sensors_config:
+## TODO: add translation and rotation
+    lfsensor: {joint_name: 'LLEG_JOINT5', frame_id: 'LLEG_LINK5', translation: [0, 0, -0.105], rotation: [1, 0, 0, 0]}
+    rfsensor: {joint_name: 'RLEG_JOINT5', frame_id: 'RLEG_LINK5', translation: [0, 0, -0.105], rotation: [1, 0, 0, 0]}
+    lhsensor: {joint_name: 'LARM_JOINT6', frame_id: 'LARM_LINK6', translation: [0, 0, -0.0775], rotation: [1, 0, 0, 0]}
+    rhsensor: {joint_name: 'RARM_JOINT6', frame_id: 'RARM_LINK6', translation: [0, 0, -0.0775], rotation: [1, 0, 0, 0]}
+  imu_sensors:
+    - imu_sensor0
+  imu_sensors_config:
+## TODO: add translation and rotation
+    imu_sensor0: {ros_name: 'waist_imu', link_name: 'CHEST_LINK1', frame_id: 'CHEST_LINK1'}

--- a/hrpsys_gazebo_tutorials/config/SampleRobot_indigo.yaml
+++ b/hrpsys_gazebo_tutorials/config/SampleRobot_indigo.yaml
@@ -1,6 +1,6 @@
 hrpsys_gazebo_configuration:
 ### velocity feedback for joint control, use parameter gains/joint_name/p_v
-  use_velocity_feedback: false
+  use_velocity_feedback: true
   use_joint_effort: true
 # iob_rate: 200
 ### loose synchronization default true
@@ -75,35 +75,35 @@ hrpsys_gazebo_configuration:
 # 28  - CHEST
 ## joint gain settings
   gains:
-    LLEG_HIP_R:      {p: 6000.0, d:  0.1, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_HIP_P:      {p: 6000.0, d:  0.15, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_HIP_Y:      {p:  2000.0, d:  0.1, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_KNEE:       {p: 9000.0, d:  0.15, i: 0.0, vp: 1.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_ANKLE_P:    {p: 4500.0, d:  0.075, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    LLEG_ANKLE_R:    {p:  3000.0, d:  0.05, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_HIP_R:      {p: 6000.0, d:  0.1, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_HIP_P:      {p: 6000.0, d:  0.05, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_HIP_Y:      {p:  2000.0, d:  0.1, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_KNEE:       {p: 9000.0, d:  0.15, i: 0.0, vp: 1.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_ANKLE_P:    {p: 4500.0, d:  0.075, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    RLEG_ANKLE_R:    {p:  3000.0, d:  0.05, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
-    WAIST_P:         {p: 8000.0, d:   0.1, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    WAIST_R:         {p: 8000.0, d:   0.1, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    CHEST:           {p: 6000.0, d:   0.05, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
-    LARM_SHOULDER_P: {p: 1200.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
-    LARM_SHOULDER_R: {p:  500.0, d:   0.05, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 120.0}
-    LARM_SHOULDER_Y: {p:  200.0, d:   0.03, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    LARM_ELBOW:      {p: 1000.0, d:   0.14, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
-    LARM_WRIST_Y:    {p:  200.0, d:   0.01, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    LARM_WRIST_P:    {p:  300.0, d:   0.02, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    LARM_WRIST_R:    {p:   20.0, d:   0.01, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    RARM_SHOULDER_P: {p: 1200.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
-    RARM_SHOULDER_R: {p:  500.0, d:   0.05, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 120.0}
-    RARM_SHOULDER_Y: {p:  200.0, d:   0.03, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    RARM_ELBOW:      {p: 1000.0, d:   0.14, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
-    RARM_WRIST_Y:    {p:  200.0, d:   0.01, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    RARM_WRIST_P:    {p:  300.0, d:   0.02, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
-    RARM_WRIST_R:    {p:   20.0, d:   0.01, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    LLEG_HIP_R:      {p: 12000.0, d:  4.0, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_HIP_P:      {p: 24000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_HIP_Y:      {p:  4000.0, d:  4.0, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_KNEE:       {p: 36000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_ANKLE_P:    {p: 18000.0, d:  3.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LLEG_ANKLE_R:    {p:  6000.0, d:  2.0, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_R:      {p: 12000.0, d:  4.0, i: 0.0, vp:  6.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_P:      {p: 24000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_HIP_Y:      {p:  4000.0, d:  4.0, i: 0.0, vp:  1.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_KNEE:       {p: 36000.0, d:  6.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_ANKLE_P:    {p: 18000.0, d:  3.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    RLEG_ANKLE_R:    {p:  6000.0, d:  2.0, i: 0.0, vp:  4.0, i_clamp: 0.0, p_v: 250.0}
+    WAIST_P:         {p: 8000.0, d:   4.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    WAIST_R:         {p: 8000.0, d:   4.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    CHEST:           {p: 6000.0, d:   2.0, i: 0.0, vp: 20.0, i_clamp: 0.0, p_v: 250.0}
+    LARM_SHOULDER_P: {p: 1200.0, d:   1.0, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    LARM_SHOULDER_R: {p:  500.0, d:   0.5, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 120.0}
+    LARM_SHOULDER_Y: {p:  200.0, d:   0.3, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    LARM_ELBOW:      {p: 1000.0, d:   1.4, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    LARM_WRIST_Y:    {p:  200.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    LARM_WRIST_P:    {p:  300.0, d:   0.2, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    LARM_WRIST_R:    {p:   20.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_SHOULDER_P: {p: 1200.0, d:   1.0, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    RARM_SHOULDER_R: {p:  500.0, d:   0.5, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 120.0}
+    RARM_SHOULDER_Y: {p:  200.0, d:   0.3, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_ELBOW:      {p: 1000.0, d:   1.4, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 160.0}
+    RARM_WRIST_Y:    {p:  200.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_WRIST_P:    {p:  300.0, d:   0.2, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
+    RARM_WRIST_R:    {p:   20.0, d:   0.1, i: 0.0, vp:  0.0, i_clamp: 0.0, p_v: 100.0}
 ## force sensor settings
 ## list of force sensorname
   force_torque_sensors:
@@ -121,7 +121,6 @@ hrpsys_gazebo_configuration:
 ## IMU sensor settings
 ## configuration of IMU sensor
 ## key of imu_sensors_config should be a member of imu_sensors
-## pose of IMU sensor should be written in URDF
   imu_sensors:
     - imu_sensor0
   imu_sensors_config:

--- a/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsk_no_controllers_indigo.launch
+++ b/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsk_no_controllers_indigo.launch
@@ -1,0 +1,18 @@
+<launch>
+  <arg name="gzname" default="gazebo"/>
+  <arg name="WORLD" default="$(find hrpsys_gazebo_general)/worlds/empty.world"/>
+  <arg name="PAUSED" default="false"/>
+  <arg name="SYNCHRONIZED" default="false" />
+
+  <include file="$(find hrpsys_gazebo_general)/launch/gazebo_robot_no_controllers.launch">
+    <arg name="ROBOT_TYPE" value="HRP2JSK" />
+    <arg name="WORLD" value="$(arg WORLD)" />
+    <arg name="HRPSYS_GAZEBO_CONFIG" default="$(find hrpsys_gazebo_tutorials)/config/HRP2JSK_indigo.yaml" />
+    <arg name="ROBOT_MODEL" default="$(find hrpsys_gazebo_tutorials)/robot_models/HRP2JSK/HRP2JSK.urdf.xacro" />
+
+    <arg name="PAUSED" value="$(arg PAUSED)"/>
+    <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
+    <arg name="USE_INSTANCE_NAME" value="true" />
+    <arg name="gzname" value="$(arg gzname)" />
+  </include>
+</launch>

--- a/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsknt_no_controllers_indigo.launch
+++ b/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsknt_no_controllers_indigo.launch
@@ -1,0 +1,23 @@
+<launch>
+  <arg name="gzname" default="gazebo"/>
+  <arg name="WORLD" default="$(find hrpsys_gazebo_general)/worlds/empty.world"/>
+  <arg name="PAUSED" default="false"/>
+  <arg name="SYNCHRONIZED" default="false" />
+
+  <rosparam command="load"
+            file="$(find hrpsys_gazebo_tutorials)/config/HRP3HAND_L.yaml" ns="HRP3HAND_L" />
+  <rosparam command="load"
+            file="$(find hrpsys_gazebo_tutorials)/config/HRP3HAND_R.yaml" ns="HRP3HAND_R" />
+
+  <include file="$(find hrpsys_gazebo_general)/launch/gazebo_robot_no_controllers.launch">
+    <arg name="ROBOT_TYPE" value="HRP2JSKNT" />
+    <arg name="WORLD" value="$(arg WORLD)" />
+    <arg name="HRPSYS_GAZEBO_CONFIG" default="$(find hrpsys_gazebo_tutorials)/config/HRP2JSKNT_indigo.yaml" />
+    <arg name="ROBOT_MODEL" default="$(find hrpsys_gazebo_tutorials)/robot_models/HRP2JSKNT/HRP2JSKNT.urdf.xacro" />
+
+    <arg name="PAUSED" value="$(arg PAUSED)"/>
+    <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
+    <arg name="USE_INSTANCE_NAME" value="true" />
+    <arg name="gzname" value="$(arg gzname)" />
+  </include>
+</launch>

--- a/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsknts_no_controllers_indigo.launch
+++ b/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsknts_no_controllers_indigo.launch
@@ -1,0 +1,23 @@
+<launch>
+  <arg name="gzname" default="gazebo"/>
+  <arg name="WORLD" default="$(find hrpsys_gazebo_general)/worlds/empty.world"/>
+  <arg name="PAUSED" default="false"/>
+  <arg name="SYNCHRONIZED" default="false" />
+
+  <rosparam command="load"
+            file="$(find hrpsys_gazebo_tutorials)/config/HRP3HAND_L.yaml" ns="HRP3HAND_L" />
+  <rosparam command="load"
+            file="$(find hrpsys_gazebo_tutorials)/config/HRP3HAND_R.yaml" ns="HRP3HAND_R" />
+
+  <include file="$(find hrpsys_gazebo_general)/launch/gazebo_robot_no_controllers.launch">
+    <arg name="ROBOT_TYPE" value="HRP2JSKNTS" />
+    <arg name="WORLD" value="$(arg WORLD)" />
+    <arg name="HRPSYS_GAZEBO_CONFIG" default="$(find hrpsys_gazebo_tutorials)/config/HRP2JSKNTS_indigo.yaml" />
+    <arg name="ROBOT_MODEL" default="$(find hrpsys_gazebo_tutorials)/robot_models/HRP2JSKNTS/HRP2JSKNTS.urdf.xacro" />
+
+    <arg name="PAUSED" value="$(arg PAUSED)"/>
+    <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
+    <arg name="USE_INSTANCE_NAME" value="true" />
+    <arg name="gzname" value="$(arg gzname)" />
+  </include>
+</launch>

--- a/hrpsys_gazebo_tutorials/launch/gazebo_samplerobot_no_controllers_indigo.launch
+++ b/hrpsys_gazebo_tutorials/launch/gazebo_samplerobot_no_controllers_indigo.launch
@@ -1,0 +1,33 @@
+<launch>
+  <arg name="gzname" default="gazebo"/>
+  <arg name="WORLD" default="$(find hrpsys_gazebo_general)/worlds/empty.world"/>
+  <arg name="PAUSED" default="false"/>
+  <arg name="SYNCHRONIZED" default="false" />
+
+  <!-- initial robot pose -->
+  <arg name="MODEL_TRANSLATE_X" default="0.0" />
+  <arg name="MODEL_TRANSLATE_Y" default="0.0" />
+  <arg name="MODEL_TRANSLATE_Z" default="0.73" />
+  <arg name="MODEL_ROTATE_R" default="0.0" />
+  <arg name="MODEL_ROTATE_P" default="0.0" />
+  <arg name="MODEL_ROTATE_Y" default="0.0" />
+
+  <include file="$(find hrpsys_gazebo_general)/launch/gazebo_robot_no_controllers.launch">
+    <arg name="ROBOT_TYPE" value="SampleRobot" />
+    <arg name="WORLD" value="$(arg WORLD)" />
+    <arg name="HRPSYS_GAZEBO_CONFIG" default="$(find hrpsys_gazebo_tutorials)/config/SampleRobot_indigo.yaml" />
+    <arg name="ROBOT_MODEL" default="$(find hrpsys_gazebo_tutorials)/robot_models/SampleRobot/SampleRobot.urdf.xacro" />
+
+    <arg name="PAUSED" value="$(arg PAUSED)"/>
+    <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
+    <arg name="USE_INSTANCE_NAME" value="true" />
+    <arg name="gzname" value="$(arg gzname)" />
+
+    <arg name="MODEL_TRANSLATE_X" value="$(arg MODEL_TRANSLATE_X)" />
+    <arg name="MODEL_TRANSLATE_Y" value="$(arg MODEL_TRANSLATE_Y)" />
+    <arg name="MODEL_TRANSLATE_Z" value="$(arg MODEL_TRANSLATE_Z)" />
+    <arg name="MODEL_ROTATE_R" value="$(arg MODEL_ROTATE_R)" />
+    <arg name="MODEL_ROTATE_P" value="$(arg MODEL_ROTATE_P)" />
+    <arg name="MODEL_ROTATE_Y" value="$(arg MODEL_ROTATE_Y)" />
+  </include>
+</launch>

--- a/hrpsys_gazebo_tutorials/launch/hrp2jsk_hrpsys_bringup.launch
+++ b/hrpsys_gazebo_tutorials/launch/hrp2jsk_hrpsys_bringup.launch
@@ -22,5 +22,6 @@
     <arg name="HRPSYS_PY_PKG" value="hrpsys_ros_bridge_tutorials"/>
     <arg name="HRPSYS_PY_NAME" default="hrp2jsk_hrpsys_config.py"/>
     <arg name="KINEMATICS_MODE" value="$(arg KINEMATICS_MODE)"/>
+    <arg name="HRPSYS_RATE"  value="250" />
   </include>
 </launch>

--- a/hrpsys_gazebo_tutorials/launch/hrp2jsknt_hrpsys_bringup.launch
+++ b/hrpsys_gazebo_tutorials/launch/hrp2jsknt_hrpsys_bringup.launch
@@ -22,5 +22,6 @@
     <arg name="HRPSYS_PY_PKG" value="hrpsys_ros_bridge_tutorials"/>
     <arg name="HRPSYS_PY_NAME" default="hrp2jsknt_hrpsys_config.py"/>
     <arg name="KINEMATICS_MODE" value="$(arg KINEMATICS_MODE)"/>
+    <arg name="HRPSYS_RATE"  value="250" />
   </include>
 </launch>

--- a/hrpsys_gazebo_tutorials/launch/hrp2jsknts_hrpsys_bringup.launch
+++ b/hrpsys_gazebo_tutorials/launch/hrp2jsknts_hrpsys_bringup.launch
@@ -23,5 +23,6 @@
     <arg name="HRPSYS_PY_PKG" value="hrpsys_ros_bridge_tutorials"/>
     <arg name="HRPSYS_PY_NAME" default="hrp2jsknts_hrpsys_config.py"/>
     <arg name="KINEMATICS_MODE" value="$(arg KINEMATICS_MODE)"/>
+    <arg name="HRPSYS_RATE"  value="250" />
   </include>
 </launch>

--- a/hrpsys_gazebo_tutorials/launch/samplerobot_hrpsys_bringup.launch
+++ b/hrpsys_gazebo_tutorials/launch/samplerobot_hrpsys_bringup.launch
@@ -22,7 +22,8 @@
     <arg name="CONF_DIR" value="$(find hrpsys_ros_bridge_tutorials)/models" />
     <arg name="USE_INSTANCE_NAME" value="true" />
     <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
-    <arg name="HRPSYS_PY_ARGS" value="--use-unstable-rtc" />
+    <arg name="HRPSYS_PY_PKG" value="hrpsys_ros_bridge_tutorials"/>
+    <arg name="HRPSYS_PY_NAME" default="samplerobot_hrpsys_config.py"/>
     <arg name="KINEMATICS_MODE" value="$(arg KINEMATICS_MODE)"/>
     <arg name="BASE_LINK" value="WAIST_LINK0" />
   </include>

--- a/hrpsys_gazebo_tutorials/launch/samplerobot_hrpsys_bringup.launch
+++ b/hrpsys_gazebo_tutorials/launch/samplerobot_hrpsys_bringup.launch
@@ -26,5 +26,6 @@
     <arg name="HRPSYS_PY_NAME" default="samplerobot_hrpsys_config.py"/>
     <arg name="KINEMATICS_MODE" value="$(arg KINEMATICS_MODE)"/>
     <arg name="BASE_LINK" value="WAIST_LINK0" />
+    <arg name="HRPSYS_RATE"  value="500" />
   </include>
 </launch>

--- a/hrpsys_gazebo_tutorials/robot_models/HRP2JSK/HRP2JSK.urdf.xacro
+++ b/hrpsys_gazebo_tutorials/robot_models/HRP2JSK/HRP2JSK.urdf.xacro
@@ -29,6 +29,7 @@
           </accel>
         </noise>
       </imu>
+      <pose>-0.13 0 0.118 0 0 0</pose>
     </sensor>
   </gazebo>
   <!-- add Kinect plugin, link and joint without visual and collision -->

--- a/hrpsys_gazebo_tutorials/robot_models/HRP2JSKNT/HRP2JSKNT.urdf.xacro
+++ b/hrpsys_gazebo_tutorials/robot_models/HRP2JSKNT/HRP2JSKNT.urdf.xacro
@@ -29,6 +29,7 @@
           </accel>
         </noise>
       </imu>
+      <pose>-0.13 0 0.118 0 0 0</pose>
     </sensor>
   </gazebo>
   <!-- add force sensor -->

--- a/hrpsys_gazebo_tutorials/robot_models/HRP2JSKNTS/HRP2JSKNTS.urdf.xacro
+++ b/hrpsys_gazebo_tutorials/robot_models/HRP2JSKNTS/HRP2JSKNTS.urdf.xacro
@@ -29,6 +29,7 @@
           </accel>
         </noise>
       </imu>
+      <pose>-0.13 0 0.118 0 0 0</pose>
     </sensor>
   </gazebo>
   <!-- add force sensor -->

--- a/hrpsys_gazebo_tutorials/robot_models/SampleRobot/SampleRobot.urdf.xacro
+++ b/hrpsys_gazebo_tutorials/robot_models/SampleRobot/SampleRobot.urdf.xacro
@@ -30,6 +30,7 @@
           </accel>
         </noise>
       </imu>
+      <pose>0 0 0 1.5708 0 3.14159</pose>
     </sensor>
   </gazebo>
   <!-- add force sensor -->

--- a/hrpsys_ros_bridge_tutorials/models/hrp2jsk.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/hrp2jsk.yaml
@@ -128,3 +128,26 @@ replace_xmls:
       attribute_name: velocity
       attribute_value: 0.5
     replaced_attribute_value: 10.0
+  - match_rule:
+      tag: dynamics
+      attribute_name: friction
+      attribute_value: 0
+    replaced_attribute_value: 1
+  - match_rule:
+      tag: dynamics
+      attribute_name: damping
+      attribute_value: 0.2
+    replaced_attribute_value: 1
+  # for hands
+  - match_rule:
+      tag: inertia
+      parent_depth: 2
+      parent_attribute_name: name
+      parent_attribute_value: RARM_LINK7
+    replaced_xml: '<inertia ixx="1e-02" ixy="0" ixz="0" iyy="1e-02" iyz="0" izz="1e-02"/>'
+  - match_rule:
+      tag: inertia
+      parent_depth: 2
+      parent_attribute_name: name
+      parent_attribute_value: LARM_LINK7
+    replaced_xml: '<inertia ixx="1e-02" ixy="0" ixz="0" iyy="1e-02" iyz="0" izz="1e-02"/>'

--- a/hrpsys_ros_bridge_tutorials/models/hrp2jsknt.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/hrp2jsknt.yaml
@@ -158,7 +158,7 @@ replace_xmls:
       tag: inertia
       attribute_name: ixx
       attribute_value: '0'
-    replaced_xml: '<inertia ixx="1e-04" ixy="0" ixz="0" iyy="1e-04" iyz="0" izz="1e-04"/>'
+    replaced_xml: '<inertia ixx="1e-02" ixy="0" ixz="0" iyy="1e-02" iyz="0" izz="1e-02"/>'
   - match_rule:
       tag: gazebo
       attribute_name: reference
@@ -189,6 +189,16 @@ replace_xmls:
       attribute_name: effort
       attribute_value: 100
     replaced_attribute_value: 1000
+  - match_rule:
+      tag: dynamics
+      attribute_name: friction
+      attribute_value: 0
+    replaced_attribute_value: 1
+  - match_rule:
+      tag: dynamics
+      attribute_name: damping
+      attribute_value: 0.2
+    replaced_attribute_value: 1
   # for hands
   - match_rule:
       tag: inertia

--- a/hrpsys_ros_bridge_tutorials/models/hrp2jsknts.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/hrp2jsknts.yaml
@@ -164,7 +164,7 @@ replace_xmls:
       tag: inertia
       attribute_name: ixx
       attribute_value: '0'
-    replaced_xml: '<inertia ixx="1e-04" ixy="0" ixz="0" iyy="1e-04" iyz="0" izz="1e-04"/>'
+    replaced_xml: '<inertia ixx="1e-02" ixy="0" ixz="0" iyy="1e-02" iyz="0" izz="1e-02"/>'
   - match_rule:
       tag: gazebo
       attribute_name: reference
@@ -195,6 +195,16 @@ replace_xmls:
       attribute_name: effort
       attribute_value: 100
     replaced_attribute_value: 1000
+  - match_rule:
+      tag: dynamics
+      attribute_name: friction
+      attribute_value: 0
+    replaced_attribute_value: 1
+  - match_rule:
+      tag: dynamics
+      attribute_name: damping
+      attribute_value: 0.2
+    replaced_attribute_value: 1
   # for hands
   - match_rule:
       tag: inertia

--- a/hrpsys_ros_bridge_tutorials/models/samplerobot.yaml
+++ b/hrpsys_ros_bridge_tutorials/models/samplerobot.yaml
@@ -108,3 +108,13 @@ replace_xmls:
       attribute_name: type
       attribute_value: continuous
     replaced_attribute_value: revolute
+  - match_rule:
+      tag: dynamics
+      attribute_name: friction
+      attribute_value: 0
+    replaced_attribute_value: 1
+  - match_rule:
+      tag: dynamics
+      attribute_name: damping
+      attribute_value: 0.2
+    replaced_attribute_value: 1


### PR DESCRIPTION
This PR enables hrp2 gazebo simulation on `kinetic`.
This PR in on https://github.com/start-jsk/rtmros_gazebo/pull/236.

```
roslaunch hrpsys_gazebo_tutorials gazebo_hrp2jsk_no_controllers.launch
rtmlaunch hrpsys_gazebo_tutorials hrp2jsk_hrpsys_bringup.launch 
```
![hrp2jsk](https://user-images.githubusercontent.com/32383525/79069260-cb766b00-7d07-11ea-8252-21254077fab8.gif)


```
roslaunch hrpsys_gazebo_tutorials gazebo_hrp2jsknt_no_controllers.launch
rtmlaunch hrpsys_gazebo_tutorials hrp2jsknt_hrpsys_bringup.launch 
```
![hrp2jsknt](https://user-images.githubusercontent.com/32383525/79069314-3fb10e80-7d08-11ea-8721-130abdfb1276.gif)



```
roslaunch hrpsys_gazebo_tutorials gazebo_hrp2jsknts_no_controllers.launch
rtmlaunch hrpsys_gazebo_tutorials hrp2jsknts_hrpsys_bringup.launch 
```
![hrp2jsknts](https://user-images.githubusercontent.com/32383525/79069322-463f8600-7d08-11ea-919e-2ed97f5303c6.gif)

