### PR TITLE
[on #248 of rtmros_gazebo] add hrpsys-gazebo-atlas test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,9 @@ env:
   matrix:
     - ROS_DISTRO=indigo  USE_DEB=true
     - ROS_DISTRO=indigo  USE_DEB=false NOT_TEST_INSTALL=true
-    - ROS_DISTRO=kinetic USE_DEB=false
+    # rtmros_gazebo/hrpsys_gazebo_atlas is tested here, because tests for hrpsys_gazebo_atlas depend on rtmros_tutorials/hrpsys_ros_bridge_tutorials.
+    - ROS_DISTRO=indigo  USE_DEB=false NOT_TEST_INSTALL=true INSTALL_SRC="https://github.com/start-jsk/rtmros_gazebo.git" ADDITIONAL_TEST_PKGS="hrpsys_gazebo_atlas"
+    - ROS_DISTRO=kinetic USE_DEB=false ADDITIONAL_TEST_PKGS="hrpsys_gazebo_atlas"
 matrix:
   # allow_failures:
   #   - env: ROS_DISTRO=indigo  USE_DEB=false NOT_TEST_INSTALL=true
@@ -35,6 +37,6 @@ notifications:
     on_success: always #[always|never|change] # default: change
     on_failure: always #[always|never|change] # default: always
 before_script:
-  # rtmros_gazebo/hrpsys_gazebo_atlas is tested here, because tests for hrpsys_gazebo_atlas depend on rtmros_tutorials/hrpsys_ros_bridge_tutorials.
-  - export TEST_PKGS="`catkin_topological_order ${CI_SOURCE_PATH} --only-names` hrpsys_gazebo_atlas"
+  - if [ "${INSTALL_SRC}" != "" ]; then export BEFORE_SCRIPT="sudo apt-get install python-yaml; $(for src in $INSTALL_SRC; do name=`basename $src`; echo "python -c \"import yaml;print yaml.dump([{\\\"git\\\":{\\\"uri\\\":\\\"$src\\\",\\\"local-name\\\":\\\"$name\\\"}}], default_flow_style=False)\" >> .rosinstall;"; done) ls -al; cat .rosinstall; wstool update"; fi
+  - if [ "${ADDITIONAL_TEST_PKGS}" != "" ] && [ "${TEST_PKGS}" == "" ] ; then export TEST_PKGS="`catkin_topological_order ${CI_SOURCE_PATH} --only-names` ${ADDITIONAL_TEST_PKGS}"; fi
 script: source .travis/travis.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,4 +34,7 @@ notifications:
       - iiysaito@opensource-robotics.tokyo.jp
     on_success: always #[always|never|change] # default: change
     on_failure: always #[always|never|change] # default: always
+before_script:
+  # rtmros_gazebo/hrpsys_gazebo_atlas is tested here, because tests for hrpsys_gazebo_atlas depend on rtmros_tutorials/hrpsys_ros_bridge_tutorials.
+  - export TEST_PKGS="`catkin_topological_order ${CI_SOURCE_PATH} --only-names` hrpsys_gazebo_atlas"
 script: source .travis/travis.sh


### PR DESCRIPTION
`rtmros_gazebo` and `rtmros_tutorials` depend on each other.
It is problematic.

I changed only `rtmros_tutorials` to be dependent on `rtmros_gazebo`.
`rtmros_gazebo/hrpsys_gazebo_atlas` is not tested in `rtmros_gazebo` but tested in `rtmros_tutorials`.
https://github.com/start-jsk/rtmros_gazebo/commit/78cbeb5839880bb7c627279d1aadfb6b72690fc6