### PR TITLE
[hrpsys_gazebo_tutorials] add MODEL_TRANSLATE/ROTATE args for HRP2

### DIFF
--- a/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsk_no_controllers.launch
+++ b/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsk_no_controllers.launch
@@ -4,6 +4,13 @@
   <arg name="PAUSED" default="false"/>
   <arg name="SYNCHRONIZED" default="false" />
 
+  <arg name="MODEL_TRANSLATE_X" default="0.0" />
+  <arg name="MODEL_TRANSLATE_Y" default="0.0" />
+  <arg name="MODEL_TRANSLATE_Z" default="0.73" />
+  <arg name="MODEL_ROTATE_R" default="0.0" />
+  <arg name="MODEL_ROTATE_P" default="0.0" />
+  <arg name="MODEL_ROTATE_Y" default="0.0" />
+
   <include file="$(find hrpsys_gazebo_general)/launch/gazebo_robot_no_controllers.launch">
     <arg name="ROBOT_TYPE" value="HRP2JSK" />
     <arg name="WORLD" value="$(arg WORLD)" />
@@ -14,5 +21,12 @@
     <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
     <arg name="USE_INSTANCE_NAME" value="true" />
     <arg name="gzname" value="$(arg gzname)" />
+
+    <arg name="MODEL_TRANSLATE_X" value="$(arg MODEL_TRANSLATE_X)" />
+    <arg name="MODEL_TRANSLATE_Y" value="$(arg MODEL_TRANSLATE_Y)" />
+    <arg name="MODEL_TRANSLATE_Z" value="$(arg MODEL_TRANSLATE_Z)" />
+    <arg name="MODEL_ROTATE_R" value="$(arg MODEL_ROTATE_R)" />
+    <arg name="MODEL_ROTATE_P" value="$(arg MODEL_ROTATE_P)" />
+    <arg name="MODEL_ROTATE_Y" value="$(arg MODEL_ROTATE_Y)" />
   </include>
 </launch>

--- a/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsknt_no_controllers.launch
+++ b/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsknt_no_controllers.launch
@@ -4,6 +4,13 @@
   <arg name="PAUSED" default="false"/>
   <arg name="SYNCHRONIZED" default="false" />
 
+  <arg name="MODEL_TRANSLATE_X" default="0.0" />
+  <arg name="MODEL_TRANSLATE_Y" default="0.0" />
+  <arg name="MODEL_TRANSLATE_Z" default="0.73" />
+  <arg name="MODEL_ROTATE_R" default="0.0" />
+  <arg name="MODEL_ROTATE_P" default="0.0" />
+  <arg name="MODEL_ROTATE_Y" default="0.0" />
+
   <rosparam command="load"
             file="$(find hrpsys_gazebo_tutorials)/config/HRP3HAND_L.yaml" ns="HRP3HAND_L" />
   <rosparam command="load"
@@ -19,5 +26,12 @@
     <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
     <arg name="USE_INSTANCE_NAME" value="true" />
     <arg name="gzname" value="$(arg gzname)" />
+
+    <arg name="MODEL_TRANSLATE_X" value="$(arg MODEL_TRANSLATE_X)" />
+    <arg name="MODEL_TRANSLATE_Y" value="$(arg MODEL_TRANSLATE_Y)" />
+    <arg name="MODEL_TRANSLATE_Z" value="$(arg MODEL_TRANSLATE_Z)" />
+    <arg name="MODEL_ROTATE_R" value="$(arg MODEL_ROTATE_R)" />
+    <arg name="MODEL_ROTATE_P" value="$(arg MODEL_ROTATE_P)" />
+    <arg name="MODEL_ROTATE_Y" value="$(arg MODEL_ROTATE_Y)" />
   </include>
 </launch>

--- a/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsknts_no_controllers.launch
+++ b/hrpsys_gazebo_tutorials/launch/gazebo_hrp2jsknts_no_controllers.launch
@@ -4,6 +4,13 @@
   <arg name="PAUSED" default="false"/>
   <arg name="SYNCHRONIZED" default="false" />
 
+  <arg name="MODEL_TRANSLATE_X" default="0.0" />
+  <arg name="MODEL_TRANSLATE_Y" default="0.0" />
+  <arg name="MODEL_TRANSLATE_Z" default="0.73" />
+  <arg name="MODEL_ROTATE_R" default="0.0" />
+  <arg name="MODEL_ROTATE_P" default="0.0" />
+  <arg name="MODEL_ROTATE_Y" default="0.0" />
+
   <rosparam command="load"
             file="$(find hrpsys_gazebo_tutorials)/config/HRP3HAND_L.yaml" ns="HRP3HAND_L" />
   <rosparam command="load"
@@ -19,5 +26,12 @@
     <arg name="SYNCHRONIZED" value="$(arg SYNCHRONIZED)" />
     <arg name="USE_INSTANCE_NAME" value="true" />
     <arg name="gzname" value="$(arg gzname)" />
+
+    <arg name="MODEL_TRANSLATE_X" value="$(arg MODEL_TRANSLATE_X)" />
+    <arg name="MODEL_TRANSLATE_Y" value="$(arg MODEL_TRANSLATE_Y)" />
+    <arg name="MODEL_TRANSLATE_Z" value="$(arg MODEL_TRANSLATE_Z)" />
+    <arg name="MODEL_ROTATE_R" value="$(arg MODEL_ROTATE_R)" />
+    <arg name="MODEL_ROTATE_P" value="$(arg MODEL_ROTATE_P)" />
+    <arg name="MODEL_ROTATE_Y" value="$(arg MODEL_ROTATE_Y)" />
   </include>
 </launch>


### PR DESCRIPTION
I add `MODEL_TRANSLATE_X` `MODEL_TRANSLATE_Y` `MODEL_TRANSLATE_Z` `MODEL_ROTATE_R` `MODEL_ROTATE_P` `MODEL_ROTATE_Y` arguments for HRP2.
These arguments specifies the initial position of the robot.

launch files for other robots (SampleRobot ・ JAXON) have these arguments, 
https://github.com/start-jsk/rtmros_tutorials/blob/bec253cbce5bf4f03a3c017b3955c5a2c24c5df6/hrpsys_gazebo_tutorials/launch/gazebo_jaxon_no_controllers.launch#L14-L19
https://github.com/start-jsk/rtmros_tutorials/blob/bec253cbce5bf4f03a3c017b3955c5a2c24c5df6/hrpsys_gazebo_tutorials/launch/gazebo_samplerobot_no_controllers.launch#L8-L13
but only launch files for HRP2 do not have these arguments.