### PR TITLE
fix JAXON and JAXON_RED head pose parameters

### DIFF
--- a/hrpsys_ros_bridge_tutorials/models/JAXON.urdf.xacro
+++ b/hrpsys_ros_bridge_tutorials/models/JAXON.urdf.xacro
@@ -62,7 +62,8 @@
     <!-- <origin rpy="-0.01 0.035 -0.005" xyz="0.085 0.01 0.065"/> --> <!-- old head in 20151022 -->
     <!-- <origin rpy="-0.004 0.275 -0.01" xyz="0.1 0.01 0.085"/> --> <!-- new head in 20151022 -->
     <!-- <origin rpy="0.003 0.255 -0.02" xyz="0.1 0.01 0.085"/> --> <!-- new head in 20151125 -->
-    <origin rpy="0.015 0.035 -0.02" xyz="0.085 0.01 0.085"/> <!-- revert to old head in 20151127 -->
+    <!-- <origin rpy="0.015 0.035 -0.02" xyz="0.085 0.01 0.085"/> --> <!-- revert to old head in 20151127 -->
+    <origin rpy="0.01 0.245 0.03" xyz="0.12 -0.025 0.09"/> <!-- fix by human 20170830 -->
   </joint>
   <!-- HAND -->
   <xacro:include filename="$(find jaxon_description)/urdf/thk_hand003.urdf.xacro" />

--- a/hrpsys_ros_bridge_tutorials/models/JAXON_RED.urdf.xacro
+++ b/hrpsys_ros_bridge_tutorials/models/JAXON_RED.urdf.xacro
@@ -61,7 +61,9 @@
     <!-- calibration at 2015.12.09 with jaxon_calibration -->
     <!-- <origin xyz="0.097542410 -0.000296955 0.063307448" rpy="-0.007600616 0.046755703 -0.015569626" /> -->
     <!-- 2016.6.1 tamura kumagai by modification of mount frame -->
-    <origin rpy="-0.005 0.048 -0.020569626" xyz="0.095 0.003596955 0.075307448"/>
+    <!-- <origin rpy="-0.005 0.048 -0.020569626" xyz="0.095 0.003596955 0.075307448"/> -->
+    <!-- 2020.10.23 copy new head parameter from JAXON.urdf.xacro -->
+    <origin rpy="0.003 0.255 -0.02" xyz="0.1 0.01 0.085"/>
   </joint>
   <!-- for calibration / original offset of camera_frame
   <link name="left_camera_optical_frame" />


### PR DESCRIPTION
数年前にJAXONとJAXON_REDの頭のマウントが変わった時、ローカルで変更されていた頭の姿勢のパラメータを反映しました。