### PR TITLE
[hrpsys_ros_bridge_tutorials][JAXON_RED] remove kfp.sensorRPY_offset

### DIFF
--- a/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/urata_hrpsys_config.py
+++ b/hrpsys_ros_bridge_tutorials/src/hrpsys_ros_bridge_tutorials/urata_hrpsys_config.py
@@ -196,7 +196,6 @@ class URATAHrpsysConfigurator(HrpsysConfigurator):
         self.abc_svc.setAutoBalancerParam(abcp)
         # kf setting
         kfp=self.kf_svc.getKalmanFilterParam()[1]
-        kfp.sensorRPY_offset = [-0.015, 0.022, 0]
         kfp.R_angle=1000
         self.kf_svc.setKalmanFilterParam(kfp)
         # st setting


### PR DESCRIPTION
#599 について最終的にどの様な方法とするかは議論の必要があるかと思いますが、当面の措置として方法3にのっとりオフセット値の設定を削除しました。対応を長らく忘れており大変申し訳ありません。@kindsenior