### PR TITLE
Avoid SSL certificate verification when using svn

### DIFF
--- a/.travis.rosinstall.indigo
+++ b/.travis.rosinstall.indigo
@@ -23,7 +23,7 @@
     uri: https://github.com/jsk-ros-pkg/jsk_pr2eus
     local-name: jsk-ros-pkg/jsk_pr2eus
 - svn:
-    uri: https://svn.code.sf.net/p/jsk-ros-pkg/code/trunk/openrave_planning/collada_robots
+    uri: http://svn.code.sf.net/p/jsk-ros-pkg/code/trunk/openrave_planning/collada_robots
     local-name: jsk-ros-pkg/collada_robots
 - git:
     uri: https://github.com/start-jsk/rtmros_common


### PR DESCRIPTION
Indigoでのtravisのチェックが通らなくなっていたので原因を調べたところ、wstool updateでsvnのリポジトリを取得する際に
```
svn: E230001: Unable to connect to a repository at URL 'https://svn.code.sf.net/p/jsk-ros-pkg/code/trunk/openrave_planning/collada_robots
svn: E230001: Server SSL certificate verification failed: certificate has expired
```
と出て失敗します。
手元でjskrobotics/ros-ubuntu:14.04で`svn ls 'https://svn.code.sf.net/p/jsk-ros-pkg/code/trunk/openrave_planning/collada_robots`と実行したところこの問題が再現し、httpsではなくhttpを使用するようにして認証を回避すればリモートから取得できました。
ちなみにjskrobotics/ros-ubuntu:16.04、jskrobotics/ros-ubuntu:18.04でも試しましたが、16.04は同様に失敗し18.04は成功しました。

以前のPRではindigoのテストが通っていたので最近仕様が変わったものと思われます。