### PR TITLE
[CI] Update jsk_travis to 0.5.25 & update checkout to avoid permission error

### DIFF
--- a/.github/workflows/indigo.yml
+++ b/.github/workflows/indigo.yml
@@ -23,7 +23,9 @@ jobs:
           sudo chmod 777 -R /__w/
           sudo chown -R $USER $HOME
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
+        with:
+          submodules: true
       - name: Run jsk_travis
         uses: jsk-ros-pkg/jsk_travis@master
         with:

--- a/.github/workflows/kinetic.yml
+++ b/.github/workflows/kinetic.yml
@@ -19,7 +19,9 @@ jobs:
           set -x
           git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
+        with:
+          submodules: true
       - name: Run jsk_travis
         uses: jsk-ros-pkg/jsk_travis@master
         with:

--- a/.github/workflows/melodic.yml
+++ b/.github/workflows/melodic.yml
@@ -19,7 +19,9 @@ jobs:
           set -x
           git config --global --add safe.directory $GITHUB_WORKSPACE
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.0.2
+        with:
+          submodules: true
       - name: Run jsk_travis
         uses: jsk-ros-pkg/jsk_travis@master
         with:


### PR DESCRIPTION
Indigo test fails with `Error: EACCES: permission denied`:
https://github.com/start-jsk/rtmros_tutorials/actions/runs/3736972571/jobs/6341782989

~~We need https://github.com/jsk-ros-pkg/jsk_travis/pull/437 to pass indigo check??~~
It seems that what we really need is something like https://github.com/jsk-ros-pkg/jsk_robot/pull/1643.
Updating jsk_travis is optional, but probably recommended.