### PR TITLE
[hironx_tutorial][HIRONXJSK] Enable to subscribe all compressedDepth without hz drop

### DIFF
--- a/hironx_tutorial/config/hironxjsk_image_transport_plugins_params.yaml
+++ b/hironx_tutorial/config/hironxjsk_image_transport_plugins_params.yaml
@@ -1,0 +1,66 @@
+# FIXME: When subscribing compressedDepth, hz of image_raw drops if png_level is more than 5.
+#        CPU usage of compressedDepth creation seems too high.
+#        CPU% of nodelet_manager on htop is over 100% even when only compressedDepth is subscribed
+#        CPU: Intel(R) Xeon(R) CPU E5-2690 v3 @ 2.60GHz
+#
+# Based on https://github.com/jsk-ros-pkg/jsk_robot/pull/1493
+
+head_camera:
+  depth:
+    image:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/theora'
+      compressedDepth:
+        png_level: 5
+    image_raw:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/theora'
+      compressedDepth:
+        png_level: 5
+    image_rect:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/theora'
+      compressedDepth:
+        png_level: 5
+    image_rect_raw:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/theora'
+      compressedDepth:
+        png_level: 5
+  depth_registered:
+    image_raw:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/theora'
+      compressedDepth:
+        png_level: 5
+    sw_registered:
+      image_rect:
+        disable_pub_plugins:
+          - 'image_transport/compressed'
+          - 'image_transport/theora'
+        compressedDepth:
+          png_level: 5
+      image_rect_raw:
+        disable_pub_plugins:
+          - 'image_transport/compressed'
+          - 'image_transport/theora'
+        compressedDepth:
+          png_level: 5
+  ir:
+    image:
+      disable_pub_plugins:
+        - 'image_transport/compressed'
+        - 'image_transport/compressedDepth'
+        - 'image_transport/theora'
+  rgb:
+    image_raw:
+      disable_pub_plugins:
+        - 'image_transport/compressedDepth'
+    image_rect_color:
+        disable_pub_plugins:
+          - 'image_transport/compressedDepth'

--- a/hironx_tutorial/launch/hironxjsk_real.launch
+++ b/hironx_tutorial/launch/hironxjsk_real.launch
@@ -7,10 +7,9 @@
     <arg name="camera" value="head_camera" />
     <arg name="publish_tf" value="false" />
   </include>
-  <!-- FIXME: When subscribing compressedDepth, hz of image_raw drops if png_level is more than 5. -->
-  <!--        Usage of CPU processing camera may be too high (not 100%, though)                    -->
-  <!--        CPU: Intel(R) Xeon(R) CPU W5580 @ 3.20GHz                                            -->
-  <param name="head_camera/depth/image_raw/compressedDepth/png_level" value="5" />
+  <!-- Set image_transport_plugins parameters (png_level and disable_pub_plugins) -->
+  <rosparam file="$(find hironx_tutorial)/config/hironxjsk_image_transport_plugins_params.yaml"
+            command="load"/>
 
   <!-- Start Robot -->
   <include file="$(find hironx_ros_bridge)/launch/hironx_ros_bridge_real.launch">


### PR DESCRIPTION
Previously, only `/head_camera/depth/image_raw/compressedDepth` can be subscribed without hz drop for `rosbag record`, but nodes on remote PC may want to subscribe other `compressedDepth` topics.
The implementation is based on https://github.com/jsk-ros-pkg/jsk_robot/pull/1493

cc. @Affonso-Gui 