### PR TITLE
[hironx_tutorial]change depth_registration value from false to true to fix the gap between XYZ and color

### DIFF
--- a/hironx_tutorial/config/hironxjsk_image_transport_plugins_params.yaml
+++ b/hironx_tutorial/config/hironxjsk_image_transport_plugins_params.yaml
@@ -51,6 +51,19 @@ head_camera:
           - 'image_transport/theora'
         compressedDepth:
           png_level: 5
+    hw_registered:
+      image_rect:
+        disable_pub_plugins:
+          - 'image_transport/compressed'
+          - 'image_transport/theora'
+        compressedDepth:
+          png_level: 5
+      image_rect_raw:
+        disable_pub_plugins:
+          - 'image_transport/compressed'
+          - 'image_transport/theora'
+        compressedDepth:
+          png_level: 5
   ir:
     image:
       disable_pub_plugins:

--- a/hironx_tutorial/launch/hironxjsk_real.launch
+++ b/hironx_tutorial/launch/hironxjsk_real.launch
@@ -5,6 +5,7 @@
   <!-- Start Camera -->
   <include file="$(find openni2_launch)/launch/openni2.launch">
     <arg name="camera" value="head_camera" />
+    <arg name="depth_registration" value="true" />
     <arg name="publish_tf" value="false" />
   </include>
   <!-- Set image_transport_plugins parameters (png_level and disable_pub_plugins) -->


### PR DESCRIPTION
HIRO頭部のprime senseカメラにおいて、点群の三次元位置情報と色情報がずれていたり、RGB画像とdepth画像の位置情報がずれているといった問題があったので、openni2.launch(https://github.com/ros-drivers/openni2_launch/blob/797cc0b4b765e0701ad8b33872c530732d9d0b23/launch/openni2.launch#L27 )のdepth_registrationの値をfalseからtrueへ変更しました。

（変更前）

![Screenshot from 2024-01-11 11-28-06](https://github.com/start-jsk/rtmros_tutorials/assets/92411373/a737fd66-2726-4eb8-8cc4-08651bff6c68)

（変更後）

![Screenshot from 2024-01-11 11-24-27](https://github.com/start-jsk/rtmros_tutorials/assets/92411373/f463e07b-6aee-4772-890d-852a84617d79)

変更後は机の端の点群がより合う（変更前は床面の黒色が変更後よりずれて表れてしまっている）ようになりました。