### PR TITLE
[hironx_tutorial/hironxjsk_real.launch]publish real hand joint state

### DIFF
--- a/hironx_tutorial/euslisp/hand-joint-state-publisher-real.l
+++ b/hironx_tutorial/euslisp/hand-joint-state-publisher-real.l
@@ -1,0 +1,18 @@
+#!/usr/bin/env roseus
+
+(load "package://hrpsys_ros_bridge_tutorials/euslisp/hironxjsk-interface.l")
+
+(hironxjsk-init)
+
+(setq pub-rate (ros::get-param "~publish_rate" 5))
+
+(ros::advertise "joint_states" sensor_msgs::JointState 1)
+(ros::rate pub-rate)
+(while (ros::ok)
+  (setq msg (instance sensor_msgs::JointState :init))
+  (send msg :header :stamp (ros::time-now))
+  (send msg :name (list "RHAND_JOINT0" "RHAND_JOINT1" "RHAND_JOINT2" "RHAND_JOINT3" "LHAND_JOINT0" "LHAND_JOINT1" "LHAND_JOINT2" "LHAND_JOINT3"))
+  (send msg :position (map float-vector #'deg2rad (send *ri* :hand-angle-vector :hands)))
+  (ros::publish "joint_states" msg)
+  (ros::sleep)
+  )

--- a/hironx_tutorial/launch/hironxjsk_real.launch
+++ b/hironx_tutorial/launch/hironxjsk_real.launch
@@ -1,6 +1,8 @@
 <launch>
 
   <arg name="launch_sound_play" default="true" />
+  <arg name="publish_real_hand_joint_state" default="false" />
+  <arg name="real_hand_joint_state_rate" default="5" />
 
   <!-- Start Camera -->
   <include file="$(find openni2_launch)/launch/openni2.launch">
@@ -17,7 +19,17 @@
     <arg name="nameserver" value="hiro014" />
     <arg name="USE_IMPEDANCECONTROLLER" value="true" />
     <arg name="USE_COLLISIONCHECK" value="true" />
+    <arg name="USE_HAND_JOINT_STATE_PUBLISHER" value="true" unless="$(arg publish_real_hand_joint_state)" />
+    <arg name="USE_HAND_JOINT_STATE_PUBLISHER" value="false" if="$(arg publish_real_hand_joint_state)" />
   </include>
+  <group if="$(arg publish_real_hand_joint_state)">
+    <node name="hand_joint_state_publisher_real"
+          pkg="hironx_tutorial" type="hand-joint-state-publisher-real.l">
+      <rosparam subst_value="True">
+        publish_rate: $(arg real_hand_joint_state_rate)
+      </rosparam>
+    </node>
+  </group>
 
   <!-- Publish odom tf -->
   <node name="odom_tf_publisher"


### PR DESCRIPTION
Previously the states of hand joint were published as dummy angles using [hand_joint_state_publisher.py](https://github.com/start-jsk/rtmros_hironx/blob/f2de65edcd1f75bd41b6877b58a4573f1f8a4a36/hironx_ros_bridge/scripts/hand_joint_state_publisher.py) and do not follow the real state. 
In this PR, `hand-joint-state-publisher.l` publishes the real hand-joint states.  The real states are published if you set `publish_real_hand_joint_state` to true in a launch file. The `real_hand_joint_state_rate` sets the publish rate.
The actual angles followed are shown below.  In this experiment, the actual robot is taking the `start-grasp` pose.

(before)The hand displayed in rviz does not reflect the actual angle, but always displays the angle published in dummy.
![Screenshot from 2024-01-23 12-04-29](https://github.com/start-jsk/rtmros_tutorials/assets/92411373/fa63d733-92a2-45cd-8b9e-d4475b3190e0)

(after)The hand displayed in rviz now reflects the actual angle.
![Screenshot from 2024-01-23 12-01-03](https://github.com/start-jsk/rtmros_tutorials/assets/92411373/30239629-d69d-43b4-a97e-26da92f9a9c1)

