### PR TITLE
[hrpsys_ros_bridge_tutorials] Enable to compile on pure Ubuntu Focal

### DIFF
--- a/hrpsys_ros_bridge_tutorials/CMakeLists.txt
+++ b/hrpsys_ros_bridge_tutorials/CMakeLists.txt
@@ -543,6 +543,14 @@ else ()
   set(euscollada_PACKAGE_PATH ${euscollada_PREFIX}/share/euscollada)
 endif()
 
+# enable to execute with correct python version
+# cf. https://github.com/tork-a/openrtm_aist_python-release/pull/5
+find_package(PythonInterp QUIET)
+if(NOT PYTHONINTERP_FOUND)
+  find_package(Python REQUIRED)
+  set(PYTHON_EXECUTABLE ${Python_EXECUTABLE})
+endif()
+
 macro (generate_hand_attached_hrp2_model _robot_name)
   set(_model_dir "${PROJECT_SOURCE_DIR}/models/")
   set(_in_urdf_file "${_model_dir}/${_robot_name}.urdf")
@@ -551,7 +559,7 @@ macro (generate_hand_attached_hrp2_model _robot_name)
   string(TOLOWER ${_robot_name} _srobot_name)
   message("generate hand_attached_hrp2_model for ${_robot_name}")
   add_custom_command(OUTPUT ${_out_urdf_file}
-      COMMAND ${_script_file}
+      COMMAND ${PYTHON_EXECUTABLE} ${_script_file}
       LARM_LINK6 RARM_LINK6 ${_in_urdf_file} ${_out_urdf_file}
       DEPENDS ${_in_urdf_file} ${_script_file} ${_srobot_name}_${PROJECT_NAME}_compile_urdf)
 endmacro()
@@ -577,7 +585,7 @@ macro (attach_sensor_and_endeffector_to_hrp2jsk_urdf
   set(_out_urdf_file "${_model_dir}/${_out_file}")
   set(_script_file ${euscollada_PACKAGE_PATH}/scripts/add_sensor_to_collada.py)
   add_custom_command(OUTPUT ${_out_urdf_file}
-    COMMAND ${_script_file}
+    COMMAND ${PYTHON_EXECUTABLE} ${_script_file}
     ${_in_urdf_file} -O ${_out_urdf_file} -C ${_in_yaml_file}
     DEPENDS ${_in_urdf_file} ${_in_yaml_file} ${_script_file})
   list(APPEND compile_urdf_robots ${_out_urdf_file})

--- a/hrpsys_ros_bridge_tutorials/models/gen_hand_attached_staro_model.sh
+++ b/hrpsys_ros_bridge_tutorials/models/gen_hand_attached_staro_model.sh
@@ -10,7 +10,18 @@ INPUT_FILE=$2
 EUSCOLLADA_PATH=$3
 BODY_FILE=${INPUT_FILE//.urdf/_body.urdf}
 
+# enable to execute with correct python version
+# cf. https://github.com/tork-a/openrtm_aist_python-release/pull/5
+if command -v python3 &>/dev/null; then
+    PYTHON_EXECUTABLE=$(command -v python3)
+elif command -v python &>/dev/null; then
+    PYTHON_EXECUTABLE=$(command -v python)
+else
+    echo "Cannot find python executable"
+    exit 1
+fi
+
 tmp1=`mktemp`
 tmp2=`mktemp`
-${EUSCOLLADA_PATH}/scripts/remove_sensor_from_urdf.py LARM_LINK7 $INPUT_FILE $tmp1
-${EUSCOLLADA_PATH}/scripts/remove_sensor_from_urdf.py RARM_LINK7 $tmp1 $BODY_FILE
+${PYTHON_EXECUTABLE} ${EUSCOLLADA_PATH}/scripts/remove_sensor_from_urdf.py LARM_LINK7 $INPUT_FILE $tmp1
+${PYTHON_EXECUTABLE} ${EUSCOLLADA_PATH}/scripts/remove_sensor_from_urdf.py RARM_LINK7 $tmp1 $BODY_FILE

--- a/hrpsys_ros_bridge_tutorials/models/gen_sensor_attached_staro_model.sh
+++ b/hrpsys_ros_bridge_tutorials/models/gen_sensor_attached_staro_model.sh
@@ -9,11 +9,22 @@ input_urdf=$3
 output_urdf=$4
 yaml_file=$5
 
+# enable to execute with correct python version
+# cf. https://github.com/tork-a/openrtm_aist_python-release/pull/5
+if command -v python3 &>/dev/null; then
+    PYTHON_EXECUTABLE=$(command -v python3)
+elif command -v python &>/dev/null; then
+    PYTHON_EXECUTABLE=$(command -v python)
+else
+    echo "Cannot find python executable"
+    exit 1
+fi
+
 # generating model with sensors
 function add_sensor_to_tmp_urdf()
 {
     tmp_model=`mktemp`
-    ${eusurdf_path}/scripts/add_sensor_to_urdf.py $@ $tmp_model
+    ${PYTHON_EXECUTABLE} ${eusurdf_path}/scripts/add_sensor_to_urdf.py $@ $tmp_model
     if [ $? == 0 ]; then
         echo $tmp_model
     else
@@ -24,7 +35,7 @@ function add_sensor_to_tmp_urdf()
 function add_eef_to_tmp_urdf()
 {
     tmp_model=`mktemp`
-    ${eusurdf_path}/scripts/add_eef_to_urdf.py $@ $tmp_model
+    ${PYTHON_EXECUTABLE} ${eusurdf_path}/scripts/add_eef_to_urdf.py $@ $tmp_model
     if [ $? == 0 ]; then
         echo $tmp_model
     else
@@ -59,7 +70,7 @@ function generate_staro_model()
 #     # tmp_model11=$(add_sensor_to_tmp_urdf 0 0.2 -0.2 0 0 1.57 LARM_LINK6 LARM_cb_jig $tmp_model10)
 #     # tmp_model12=$(add_sensor_to_tmp_urdf 0 -0.2 -0.2 0 0 1.57 RARM_LINK6 RARM_cb_jig $tmp_model11)
 #     cp $tmp_model4 $2
-    ${eusurdf_path}/scripts/add_sensor_to_collada.py $1 -O $2 -C $3
+    ${PYTHON_EXECUTABLE} ${eusurdf_path}/scripts/add_sensor_to_collada.py $1 -O $2 -C $3
 }
 
 generate_staro_model $input_urdf $output_urdf $yaml_file


### PR DESCRIPTION
Currently, building `hrpsys_ros_bridge_tutorials` on pure Ubuntu Focal fails due to the following errors:
```
/usr/bin/env: ‘python’: No such file or directory
make[2]: *** [CMakeFiles/all_urdf_model_generate.dir/build.make:71: /root/hiro_ws/src/rtmros_tutorials/hrpsys_ros_bridge_tutorials/models/HRP2JSK_WH_SENSORS.urdf] Error 127
make[1]: *** [CMakeFiles/Makefile2:7527: CMakeFiles/all_urdf_model_generate.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```
```
/usr/bin/env: ‘python’: No such file or directory
make[2]: *** [CMakeFiles/all_urdf_model_generate.dir/build.make:107: /root/hiro_ws/src/rtmros_tutorials/hrpsys_ros_bridge_tutorials/models/CHIDORI_SENSORS.urdf] Error 127
make[1]: *** [CMakeFiles/Makefile2:7527: CMakeFiles/all_urdf_model_generate.dir/all] Error 2
make: *** [Makefile:141: all] Error 2
```

This PR fixes these errors by applying a patch similar to https://github.com/tork-a/openrtm_aist_python-release/pull/5.